### PR TITLE
Adding RunRXDiscardsCheck to framework

### DIFF
--- a/cmd/level1.go
+++ b/cmd/level1.go
@@ -68,6 +68,7 @@ func runAllLevel1Tests() error {
 		{"gpu_count_check", level1_tests.RunGPUCountCheck},
 		{"pcie_error_check", level1_tests.RunPCIeErrorCheck},
 		{"rdma_nics_count", level1_tests.RunRDMANicsCount},
+		{"rx_discards_check", level1_tests.RunRXDiscardsCheck},
 	}
 
 	var failedTests []string
@@ -126,6 +127,7 @@ func runSpecificTests(testFilter string) error {
 		{"gpu_count_check", "Check GPU count using nvidia-smi", level1_tests.RunGPUCountCheck},
 		{"pcie_error_check", "Check for PCIe errors in system logs", level1_tests.RunPCIeErrorCheck},
 		{"rdma_nics_count", "Check RDMA NICs count", level1_tests.RunRDMANicsCount},
+		{"rx_discards_check", "Check Network Interface", level1_tests.RunRDMANicsCount},
 	}
 
 	// If testFilter is empty, show available tests

--- a/cmd/level1.go
+++ b/cmd/level1.go
@@ -127,7 +127,7 @@ func runSpecificTests(testFilter string) error {
 		{"gpu_count_check", "Check GPU count using nvidia-smi", level1_tests.RunGPUCountCheck},
 		{"pcie_error_check", "Check for PCIe errors in system logs", level1_tests.RunPCIeErrorCheck},
 		{"rdma_nics_count", "Check RDMA NICs count", level1_tests.RunRDMANicsCount},
-		{"rx_discards_check", "Check Network Interface", level1_tests.RunRDMANicsCount},
+		{"rx_discards_check", "Check Network Interface for rx discard", level1_tests.RunRXDiscardsCheck},
 	}
 
 	// If testFilter is empty, show available tests

--- a/internal/Utils/utils.go
+++ b/internal/Utils/utils.go
@@ -1,0 +1,9 @@
+package Utils
+
+import "strconv"
+
+// IsInt checks if a string represents a valid integer
+func IsInt(s string) bool {
+	_, err := strconv.Atoi(s)
+	return err == nil
+}

--- a/internal/level1_tests/rx_discards_check.go
+++ b/internal/level1_tests/rx_discards_check.go
@@ -1,0 +1,193 @@
+package level1_tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-dr-hpc-v2/internal/Utils"
+	"strconv"
+	"strings"
+
+	"github.com/oracle/oci-dr-hpc-v2/internal/executor"
+	"github.com/oracle/oci-dr-hpc-v2/internal/logger"
+	"github.com/oracle/oci-dr-hpc-v2/internal/reporter"
+)
+
+// RXDiscardsResult represents the result of RX discards check for a single interface
+type RXDiscardsResult struct {
+	RXDiscards RXDiscardsDevice `json:"rx_discards"`
+}
+
+// RXDiscardsDevice represents the device-specific RX discards information
+type RXDiscardsDevice struct {
+	Device string `json:"device"`
+	Status string `json:"status"`
+}
+
+// RXDiscardsConfig represents the configuration for RX discards checking
+type RXDiscardsConfig struct {
+	Interfaces               []string `json:"interfaces"`
+	RXDiscardsCheckThreshold int      `json:"rx_discards_check_threshold"`
+}
+
+// TODO: bhrajan read configs from file
+// getRXDiscardsConfig returns the configuration for RX discards checking
+func getRXDiscardsConfig() *RXDiscardsConfig {
+	return &RXDiscardsConfig{
+		Interfaces: []string{
+			"rdma0", "rdma1",
+			"rdma2", "rdma3",
+			"rdma4", "rdma5",
+			"rdma6", "rdma7",
+			"rdma8", "rdma9",
+			"rdma10", "rdma11",
+			"rdma12", "rdma13",
+			"rdma14", "rdma15",
+		},
+		// Threshold for considering RX discards problematic
+		// Values above this indicate potential network issues
+		RXDiscardsCheckThreshold: 100,
+	}
+}
+
+// parseRXDiscardsResults parses RX discards results for a single interface
+func parseRXDiscardsResults(interfaceName string, results []string, threshold int) RXDiscardsResult {
+	// Create default result structure with PASS status
+	result := RXDiscardsResult{
+		RXDiscards: RXDiscardsDevice{
+			Device: interfaceName,
+			Status: "PASS",
+		},
+	}
+
+	// Check if ethtool command returned any results
+	if len(results) == 0 {
+		// No results means interface doesn't exist or ethtool failed
+		result.RXDiscards.Status = "FAIL"
+		return result
+	}
+
+	// Process each line of ethtool output
+	for _, line := range results {
+		if len(line) > 0 {
+			// Parse ethtool output format: "stat_name: value"
+			// Remove spaces and split on colon to extract the numeric value
+			cleanLine := strings.ReplaceAll(line, " ", "")
+			parts := strings.Split(cleanLine, ":")
+
+			if len(parts) >= 2 {
+				discardsStr := parts[1]
+
+				// Validate that the discard count is a valid integer
+				if Utils.IsInt(discardsStr) {
+					discards, _ := strconv.Atoi(discardsStr)
+					// Check if discard count exceeds threshold
+					if discards > threshold {
+						result.RXDiscards.Status = "FAIL"
+						break // Exit early on first failure
+					}
+				} else {
+					// Invalid discard value indicates parsing error or interface issue
+					result.RXDiscards.Status = "FAIL"
+					break // Exit early on parsing failure
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// runRXDiscardsCheck executes RX discards health check across all relevant network interfaces
+func runRXDiscardsCheck() ([]RXDiscardsResult, error) {
+	config := getRXDiscardsConfig()
+	interfacesList := config.Interfaces
+	threshold := config.RXDiscardsCheckThreshold
+
+	logger.Info("Running RX discards check with threshold:", threshold)
+
+	// Process each interface and collect results
+	var results []RXDiscardsResult
+
+	for _, interfaceName := range interfacesList {
+		logger.Debugf("Checking interface: %s", interfaceName)
+
+		// Execute ethtool command to get RX discards statistics
+		result, err := executor.RunEthtoolStats(interfaceName, "rx_prio.*_discards")
+		if err != nil {
+			logger.Debugf("ethtool failed for interface %s: %v", interfaceName, err)
+			// Create failed result for this interface
+			failResult := RXDiscardsResult{
+				RXDiscards: RXDiscardsDevice{
+					Device: interfaceName,
+					Status: "FAIL",
+				},
+			}
+			results = append(results, failResult)
+			continue
+		}
+
+		// Parse the results and determine pass/fail status
+		output := strings.TrimSpace(result.Output)
+		var lines []string
+		if output != "" {
+			lines = strings.Split(output, "\n")
+		}
+
+		parsedResult := parseRXDiscardsResults(interfaceName, lines, threshold)
+		results = append(results, parsedResult)
+	}
+
+	return results, nil
+}
+
+// RunRXDiscardsCheck is the main entry point for RX discards health check
+func RunRXDiscardsCheck() error {
+	logger.Info("=== RX Discards Health Check ===")
+	rep := reporter.GetReporter()
+
+	logger.Info("Health check is in progress...")
+
+	// Run the RX discards check
+	results, err := runRXDiscardsCheck()
+	if err != nil {
+		logger.Error("RX Discards Check: FAIL - Error during check:", err)
+		rep.AddNetworkRxDiscardsResult("FAIL", 0, err)
+		return fmt.Errorf("failed to run RX discards check: %w", err)
+	}
+
+	// Convert results to JSON for logging and reporting
+	jsonResults, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		logger.Error("RX Discards Check: FAIL - Failed to marshal results:", err)
+		rep.AddNetworkRxDiscardsResult("FAIL", 0, err)
+		return fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	logger.Info("RX Discards Check results:")
+	logger.Info(string(jsonResults))
+
+	// Check if any interface failed
+	failedCount := 0
+	passedCount := 0
+	for _, result := range results {
+		if result.RXDiscards.Status == "FAIL" {
+			failedCount++
+			logger.Errorf("Interface %s: FAIL", result.RXDiscards.Device)
+		} else {
+			passedCount++
+			logger.Infof("Interface %s: PASS", result.RXDiscards.Device)
+		}
+	}
+
+	// Report overall result
+	if failedCount > 0 {
+		err := fmt.Errorf("RX discards check failed for %d out of %d interfaces", failedCount, len(results))
+		logger.Error("RX Discards Check: FAIL -", err)
+		rep.AddNetworkRxDiscardsResult("FAIL", failedCount, err)
+		return err
+	}
+
+	logger.Info("RX Discards Check: PASS - All interfaces passed")
+	rep.AddNetworkRxDiscardsResult("PASS", len(results), nil)
+	return nil
+}

--- a/internal/level1_tests/rx_discards_check_test.go
+++ b/internal/level1_tests/rx_discards_check_test.go
@@ -1,0 +1,178 @@
+package level1_tests
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGetRXDiscardsConfig(t *testing.T) {
+	config := getRXDiscardsConfig()
+
+	if config == nil {
+		t.Fatal("Expected config but got nil")
+	}
+
+	if len(config.Interfaces) != 16 {
+		t.Errorf("Expected 16 interfaces, got %d", len(config.Interfaces))
+	}
+
+	if config.Interfaces[0] != "rdma0" {
+		t.Errorf("Expected first interface 'rdma0', got '%s'", config.Interfaces[0])
+	}
+
+	if config.Interfaces[15] != "rdma15" {
+		t.Errorf("Expected last interface 'rdma15', got '%s'", config.Interfaces[15])
+	}
+}
+
+func TestParseRXDiscardsResults(t *testing.T) {
+	// Test empty results (should fail)
+	result := parseRXDiscardsResults("rdma0", []string{}, 100.0)
+	if result.RXDiscards.Status != "FAIL" {
+		t.Error("Expected FAIL for empty results")
+	}
+	if result.RXDiscards.Device != "rdma0" {
+		t.Errorf("Expected device 'rdma0', got '%s'", result.RXDiscards.Device)
+	}
+
+	// Test valid results below threshold (should pass)
+	result = parseRXDiscardsResults("rdma1", []string{"rx_prio0_discards: 50"}, 100.0)
+	if result.RXDiscards.Status != "PASS" {
+		t.Error("Expected PASS for results below threshold")
+	}
+
+	// Test results above threshold (should fail)
+	result = parseRXDiscardsResults("rdma2", []string{"rx_prio0_discards: 150"}, 100.0)
+	if result.RXDiscards.Status != "FAIL" {
+		t.Error("Expected FAIL for results above threshold")
+	}
+
+	// Test invalid format (should fail)
+	result = parseRXDiscardsResults("rdma3", []string{"rx_prio0_discards: abc"}, 100.0)
+	if result.RXDiscards.Status != "FAIL" {
+		t.Error("Expected FAIL for invalid number format")
+	}
+
+	// Test exact threshold value (should pass)
+	result = parseRXDiscardsResults("rdma4", []string{"rx_prio0_discards: 100"}, 100.0)
+	if result.RXDiscards.Status != "PASS" {
+		t.Error("Expected PASS for exact threshold value")
+	}
+
+	// Test multiple lines with one exceeding threshold
+	result = parseRXDiscardsResults("rdma5", []string{"rx_prio0_discards: 50", "rx_prio1_discards: 150"}, 100.0)
+	if result.RXDiscards.Status != "FAIL" {
+		t.Error("Expected FAIL when any line exceeds threshold")
+	}
+}
+
+func TestRxDiscardTestConfig(t *testing.T) {
+	config := &RxDiscardTestConfig{
+		Threshold: 100.5,
+		IsEnabled: true,
+		Shape:     "BM.GPU.H100.8",
+	}
+
+	if config.Threshold != 100.5 {
+		t.Errorf("Expected threshold 100.5, got %f", config.Threshold)
+	}
+
+	if !config.IsEnabled {
+		t.Error("Expected IsEnabled to be true")
+	}
+
+	if config.Shape != "BM.GPU.H100.8" {
+		t.Errorf("Expected shape 'BM.GPU.H100.8', got '%s'", config.Shape)
+	}
+}
+
+func TestRXDiscardsResultJSON(t *testing.T) {
+	result := RXDiscardsResult{
+		RXDiscards: RXDiscardsDevice{
+			Device: "rdma0",
+			Status: "PASS",
+		},
+	}
+
+	// Test JSON marshaling
+	jsonData, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("Failed to marshal to JSON: %v", err)
+	}
+
+	// Test JSON unmarshaling
+	var unmarshaled RXDiscardsResult
+	err = json.Unmarshal(jsonData, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal from JSON: %v", err)
+	}
+
+	if unmarshaled.RXDiscards.Device != result.RXDiscards.Device {
+		t.Errorf("Expected device '%s', got '%s'", result.RXDiscards.Device, unmarshaled.RXDiscards.Device)
+	}
+
+	if unmarshaled.RXDiscards.Status != result.RXDiscards.Status {
+		t.Errorf("Expected status '%s', got '%s'", result.RXDiscards.Status, unmarshaled.RXDiscards.Status)
+	}
+}
+
+func TestParseRXDiscardsResultsEdgeCases(t *testing.T) {
+	// Test empty lines mixed with valid data
+	result := parseRXDiscardsResults("rdma0", []string{"", "rx_prio0_discards: 50", ""}, 100.0)
+	if result.RXDiscards.Status != "PASS" {
+		t.Error("Expected PASS with empty lines in data")
+	}
+
+	// Test malformed line without colon
+	result = parseRXDiscardsResults("rdma1", []string{"invalid line format"}, 100.0)
+	if result.RXDiscards.Status != "PASS" {
+		t.Error("Expected PASS for malformed line without colon")
+	}
+
+	// Test line with multiple colons
+	result = parseRXDiscardsResults("rdma2", []string{"rx_prio0_discards: test: 50"}, 100.0)
+	if result.RXDiscards.Status != "FAIL" {
+		t.Error("Expected FAIL for invalid number after multiple colons")
+	}
+
+	// Test zero threshold
+	result = parseRXDiscardsResults("rdma3", []string{"rx_prio0_discards: 1"}, 0.0)
+	if result.RXDiscards.Status != "FAIL" {
+		t.Error("Expected FAIL when value exceeds zero threshold")
+	}
+
+	// Test negative numbers
+	result = parseRXDiscardsResults("rdma4", []string{"rx_prio0_discards: -5"}, 100.0)
+	if result.RXDiscards.Status != "PASS" {
+		t.Error("Expected PASS for negative number below threshold")
+	}
+}
+
+func TestRXDiscardsStructures(t *testing.T) {
+	// Test RXDiscardsDevice
+	device := RXDiscardsDevice{
+		Device: "rdma10",
+		Status: "FAIL",
+	}
+
+	if device.Device != "rdma10" {
+		t.Errorf("Expected device 'rdma10', got '%s'", device.Device)
+	}
+
+	if device.Status != "FAIL" {
+		t.Errorf("Expected status 'FAIL', got '%s'", device.Status)
+	}
+
+	// Test RXDiscardsResult
+	result := RXDiscardsResult{
+		RXDiscards: device,
+	}
+
+	if result.RXDiscards.Device != "rdma10" {
+		t.Errorf("Expected nested device 'rdma10', got '%s'", result.RXDiscards.Device)
+	}
+
+	if result.RXDiscards.Status != "FAIL" {
+		t.Errorf("Expected nested status 'FAIL', got '%s'", result.RXDiscards.Status)
+	}
+}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -46,6 +46,7 @@ type NetworkRXDiscardsTestResult struct {
 	InterfaceCount int    `json:"interface_count"`
 	FailedCount    int    `json:"failed_count,omitempty"`
 	Status         string `json:"status"`
+	TimestampUTC   string `json:"timestamp_utc"`
 }
 
 // HostResults represents test results for a host
@@ -264,6 +265,7 @@ func (r *Reporter) GenerateReport() (*ReportOutput, error) {
 			InterfaceCount: interfaceCount,
 			FailedCount:    failedCount,
 			Status:         result.Status,
+			TimestampUTC:   result.Timestamp.UTC().Format(time.RFC3339),
 		}
 		report.Localhost.NetworkRXDiscards = []NetworkRXDiscardsTestResult{networkResult}
 	}
@@ -387,9 +389,9 @@ func (r *Reporter) formatTable(report *ReportOutput) (string, error) {
 	var output strings.Builder
 
 	output.WriteString("┌─────────────────────────────────────────────────────────────────┐\n")
-	output.WriteString("│                    DIAGNOSTIC TEST RESULTS                     │\n")
+	output.WriteString("│                    DIAGNOSTIC TEST RESULTS                      │\n")
 	output.WriteString("├─────────────────────────────────────────────────────────────────┤\n")
-	output.WriteString("│ TEST NAME              │ STATUS │ DETAILS                     │\n")
+	output.WriteString("│ TEST NAME              │ STATUS │ DETAILS                       │\n")
 	output.WriteString("├─────────────────────────────────────────────────────────────────┤\n")
 
 	// GPU Tests
@@ -400,7 +402,7 @@ func (r *Reporter) formatTable(report *ReportOutput) (string, error) {
 			if status == "FAIL" {
 				statusSymbol = "❌"
 			}
-			output.WriteString(fmt.Sprintf("│ %-22s │ %-6s │ %s GPU Count: %s          │\n",
+			output.WriteString(fmt.Sprintf("│ %-22s │ %-6s │ %s GPU Count: %s           │\n",
 				"GPU Count Check", statusSymbol, statusSymbol, gpu.Status))
 		}
 	}
@@ -426,7 +428,7 @@ func (r *Reporter) formatTable(report *ReportOutput) (string, error) {
 			if status == "FAIL" {
 				statusSymbol = "❌"
 			}
-			output.WriteString(fmt.Sprintf("│ %-22s │ %-6s │ %s RDMA NICs: %d            │\n",
+			output.WriteString(fmt.Sprintf("│ %-22s │ %-6s │ %s RDMA NICs: %d             │\n",
 				"RDMA NIC Count", statusSymbol, statusSymbol, rdma.NumRDMANics))
 		}
 	}
@@ -443,7 +445,7 @@ func (r *Reporter) formatTable(report *ReportOutput) (string, error) {
 			if network.FailedCount > 0 {
 				details = fmt.Sprintf("Failed: %d/%d", network.FailedCount, network.InterfaceCount)
 			}
-			output.WriteString(fmt.Sprintf("│ %-22s │ %-6s │ %s %s          │\n",
+			output.WriteString(fmt.Sprintf("│ %-22s │ %-6s │ %s %s            │\n",
 				"Network RX Discards", statusSymbol, statusSymbol, details))
 		}
 	}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -41,11 +41,19 @@ type RDMATestResult struct {
 	TimestampUTC string `json:"timestamp_utc"`
 }
 
+// NetworkTestResult represents network test results
+type NetworkRXDiscardsTestResult struct {
+	InterfaceCount int    `json:"interface_count"`
+	FailedCount    int    `json:"failed_count,omitempty"`
+	Status         string `json:"status"`
+}
+
 // HostResults represents test results for a host
 type HostResults struct {
-	GPUCountCheck  []GPUTestResult  `json:"gpu_count_check,omitempty"`
-	PCIeErrorCheck []PCIeTestResult `json:"pcie_error_check,omitempty"`
-	RDMANicsCount  []RDMATestResult `json:"rdma_nics_count,omitempty"`
+	GPUCountCheck     []GPUTestResult               `json:"gpu_count_check,omitempty"`
+	PCIeErrorCheck    []PCIeTestResult              `json:"pcie_error_check,omitempty"`
+	RDMANicsCount     []RDMATestResult              `json:"rdma_nics_count,omitempty"`
+	NetworkRXDiscards []NetworkRXDiscardsTestResult `json:"network_rx_discards,omitempty"`
 }
 
 // ReportOutput represents the final JSON output structure
@@ -167,6 +175,24 @@ func (r *Reporter) AddRDMAResult(status string, rdmaNicCount int, err error) {
 	r.AddResult("rdma_nic_count", status, details, err)
 }
 
+// AddNetworkRxDiscardsResult adds network discards test results
+func (r *Reporter) AddNetworkRxDiscardsResult(status string, interfaceCount int, err error) {
+	details := map[string]interface{}{
+		"interface_count": interfaceCount,
+	}
+
+	// Add failed count if status is FAIL and it's available from the error
+	if status == "FAIL" {
+		// For network tests, interfaceCount might represent failed interfaces
+		// when status is FAIL, otherwise it represents total interfaces checked
+		if status == "FAIL" {
+			details["failed_count"] = interfaceCount
+		}
+	}
+
+	r.AddResult("network_rx_discards", status, details, err)
+}
+
 // GenerateReport generates the final JSON report
 func (r *Reporter) GenerateReport() (*ReportOutput, error) {
 	r.mutex.RLock()
@@ -215,6 +241,31 @@ func (r *Reporter) GenerateReport() (*ReportOutput, error) {
 			TimestampUTC: result.Timestamp.UTC().Format(time.RFC3339),
 		}
 		report.Localhost.RDMANicsCount = []RDMATestResult{rdmaResult}
+	}
+
+	// Process Network results
+	if result, exists := r.results["network_rx_discards"]; exists {
+		interfaceCount := 0
+		failedCount := 0
+
+		if countVal, ok := result.Details["interface_count"]; ok {
+			if count, ok := countVal.(int); ok {
+				interfaceCount = count
+			}
+		}
+
+		if failedVal, ok := result.Details["failed_count"]; ok {
+			if count, ok := failedVal.(int); ok {
+				failedCount = count
+			}
+		}
+
+		networkResult := NetworkRXDiscardsTestResult{
+			InterfaceCount: interfaceCount,
+			FailedCount:    failedCount,
+			Status:         result.Status,
+		}
+		report.Localhost.NetworkRXDiscards = []NetworkRXDiscardsTestResult{networkResult}
 	}
 
 	return report, nil
@@ -380,6 +431,23 @@ func (r *Reporter) formatTable(report *ReportOutput) (string, error) {
 		}
 	}
 
+	// Network Tests
+	if len(report.Localhost.NetworkRXDiscards) > 0 {
+		for _, network := range report.Localhost.NetworkRXDiscards {
+			status := network.Status
+			statusSymbol := "✅"
+			if status == "FAIL" {
+				statusSymbol = "❌"
+			}
+			details := fmt.Sprintf("Interfaces: %d", network.InterfaceCount)
+			if network.FailedCount > 0 {
+				details = fmt.Sprintf("Failed: %d/%d", network.FailedCount, network.InterfaceCount)
+			}
+			output.WriteString(fmt.Sprintf("│ %-22s │ %-6s │ %s %s          │\n",
+				"Network RX Discards", statusSymbol, statusSymbol, details))
+		}
+	}
+
 	output.WriteString("└─────────────────────────────────────────────────────────────────┘\n")
 	return output.String(), nil
 }
@@ -441,6 +509,27 @@ func (r *Reporter) formatFriendly(report *ReportOutput) (string, error) {
 			} else {
 				failedTests++
 				output.WriteString(fmt.Sprintf("   ❌ RDMA NICs: %d detected (FAILED)\n", rdma.NumRDMANics))
+			}
+		}
+		output.WriteString("\n")
+	}
+
+	// Network Tests
+	if len(report.Localhost.NetworkRXDiscards) > 0 {
+		output.WriteString("🌐 Network RX Discards Check\n")
+		output.WriteString("   " + strings.Repeat("-", 30) + "\n")
+		for _, network := range report.Localhost.NetworkRXDiscards {
+			totalTests++
+			if network.Status == "PASS" {
+				passedTests++
+				output.WriteString(fmt.Sprintf("   ✅ Network Interfaces: %d checked, no RX discard issues (PASSED)\n", network.InterfaceCount))
+			} else {
+				failedTests++
+				if network.FailedCount > 0 {
+					output.WriteString(fmt.Sprintf("   ❌ Network Interfaces: %d failed out of %d checked (FAILED)\n", network.FailedCount, network.InterfaceCount))
+				} else {
+					output.WriteString(fmt.Sprintf("   ❌ Network Interfaces: RX discard check failed (FAILED)\n"))
+				}
 			}
 		}
 		output.WriteString("\n")

--- a/internal/test_limits/README.md
+++ b/internal/test_limits/README.md
@@ -1,0 +1,16 @@
+# Dr-HPC Test Limits
+
+## Overview
+**Dr-HPC** uses the `test_limits` package (`test_limits.json`) to determine test configurations and thresholds for various HPC shapes.
+
+## Purpose
+The `test_limits` package provides the following key information:
+- **Test Enablement:** Determines whether a specific test is enabled for a given shape.
+- **Thresholds and Limits:** Defines the acceptable thresholds or performance limits for each test within a shape.
+- **Test Categorization:** Specifies the category each test belongs to for better organization and reporting.
+
+## File Reference
+- **Configuration File:** `test_limits.json`
+
+## Notes
+Ensure that the `test_limits.json` file is up-to-date to accurately reflect the supported shapes, thresholds, and test categories.

--- a/internal/test_limits/test_limits.go
+++ b/internal/test_limits/test_limits.go
@@ -1,0 +1,135 @@
+package test_limits
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/oracle/oci-dr-hpc-v2/internal/logger"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// SRAMThreshold represents the threshold configuration for SRAM checks
+type SRAMThreshold struct {
+	Uncorrectable int `json:"uncorrectable"`
+	Correctable   int `json:"correctable"`
+}
+
+// TestConfig represents a generic test configuration that can be extended
+type TestConfig struct {
+	Enabled      bool        `json:"enabled"`
+	TestCategory string      `json:"test_category"`
+	Threshold    interface{} `json:"threshold,omitempty"`
+}
+
+// ShapeTestConfig represents the test configuration for a specific shape
+// Uses map to allow dynamic addition of new test types
+type ShapeTestConfig map[string]*TestConfig
+
+// TestLimits represents the complete test limits configuration
+type TestLimits struct {
+	TestLimits map[string]ShapeTestConfig `json:"test_limits"`
+}
+
+// getPackageDir returns the directory where this package resides
+func getPackageDir() (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("unable to get current file path")
+	}
+	return filepath.Dir(filename), nil
+}
+
+// getDefaultConfigPath returns the default path for test_limits.json
+func getDefaultConfigPath() (string, error) {
+	packageDir, err := getPackageDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(packageDir, "test_limits.json"), nil
+}
+
+// LoadTestLimits reads and parses the test limits JSON configuration file from the package directory
+func LoadTestLimits() (*TestLimits, error) {
+	configPath, err := getDefaultConfigPath()
+	logger.Infof("LoadTestLimits: using config path %s", configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine config path: %w", err)
+	}
+	return LoadTestLimitsFromFile(configPath)
+}
+
+// LoadTestLimitsFromFile reads and parses the test limits JSON configuration file from a specific path
+func LoadTestLimitsFromFile(filePath string) (*TestLimits, error) {
+	// Read the file
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		logger.Errorf("Unable to read test limits file: %s", filePath)
+		return nil, fmt.Errorf("failed to read test limits file %s: %w", filePath, err)
+	}
+
+	// Parse the JSON
+	var testLimits TestLimits
+	if err := json.Unmarshal(data, &testLimits); err != nil {
+		logger.Errorf("failed to parse test limits JSON: %s", filePath)
+		return nil, fmt.Errorf("failed to parse test limits JSON: %w", err)
+	}
+	logger.Infof("Test configs: %+v", testLimits)
+
+	return &testLimits, nil
+}
+
+// GetTestConfig returns the configuration for a specific test type and shape
+func (tl *TestLimits) GetTestConfig(shapeName, testType string) (*TestConfig, error) {
+	if shapeConfig, exists := tl.TestLimits[shapeName]; exists {
+		if testConfig, exists := shapeConfig[testType]; exists {
+			return testConfig, nil
+		}
+		return nil, fmt.Errorf("test type %s not found for shape %s", testType, shapeName)
+	}
+	return nil, fmt.Errorf("no test configuration found for shape: %s", shapeName)
+}
+
+// IsTestEnabled returns whether a specific test is enabled for a shape
+func (tl *TestLimits) IsTestEnabled(shapeName, testType string) (bool, error) {
+	testConfig, err := tl.GetTestConfig(shapeName, testType)
+	if err != nil {
+		return false, err
+	}
+	return testConfig.Enabled, nil
+}
+
+// GetThresholdForTest returns the raw threshold value for any test type (extensible)
+func (tl *TestLimits) GetThresholdForTest(shapeName, testType string) (interface{}, error) {
+	testConfig, err := tl.GetTestConfig(shapeName, testType)
+	if err != nil {
+		return nil, err
+	}
+	if !testConfig.Enabled {
+		return nil, fmt.Errorf("test %s is disabled for shape: %s", testType, shapeName)
+	}
+	return testConfig.Threshold, nil
+}
+
+// GetAvailableShapes returns a list of all available shape names
+func (tl *TestLimits) GetAvailableShapes() []string {
+	shapes := make([]string, 0, len(tl.TestLimits))
+	for shapeName := range tl.TestLimits {
+		shapes = append(shapes, shapeName)
+	}
+	return shapes
+}
+
+// GetEnabledTests returns a list of enabled test types for a specific shape
+func (tl *TestLimits) GetEnabledTests(shapeName string) ([]string, error) {
+	if shapeConfig, exists := tl.TestLimits[shapeName]; exists {
+		var enabledTests []string
+		for testType, testConfig := range shapeConfig {
+			if testConfig.Enabled {
+				enabledTests = append(enabledTests, testType)
+			}
+		}
+		return enabledTests, nil
+	}
+	return nil, fmt.Errorf("no test configuration found for shape: %s", shapeName)
+}

--- a/internal/test_limits/test_limits.json
+++ b/internal/test_limits/test_limits.json
@@ -1,0 +1,38 @@
+{
+  "test_limits" : {
+    "BM.GPU.H100.8": {
+      "gid_index_check": {
+        "enabled": true,
+        "test_category": "LEVEL_1",
+        "threshold": [ 0, 1, 2, 3]
+      },
+      "rx_discards_check": {
+        "enabled": true,
+        "test_category": "LEVEL_1",
+        "threshold":100
+      },
+      "sram_error_check": {
+        "enabled": true,
+        "test_category": "LEVEL_1",
+        "threshold": {
+          "uncorrectable": 10,
+          "correctable": 100
+        }
+      }
+    },
+    "BM.GPU.B200.8": {
+      "gid_index_check": {
+        "enabled": false,
+        "test_category": "LEVEL_1"
+      },
+      "rx_discards_check": {
+        "enabled": false,
+        "test_category": "LEVEL_1"
+      },
+      "sram_error_check": {
+        "enabled": false,
+        "test_category": "LEVEL_1"
+      }
+    }
+  }
+}

--- a/internal/test_limits/test_limits_test.go
+++ b/internal/test_limits/test_limits_test.go
@@ -1,0 +1,330 @@
+package test_limits
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadTestLimits(t *testing.T) {
+	// Test loading from default location
+	limits, err := LoadTestLimits()
+	if err != nil {
+		t.Fatalf("Failed to load test limits: %v", err)
+	}
+
+	if limits == nil {
+		t.Fatal("Expected test limits but got nil")
+	}
+
+	if len(limits.TestLimits) == 0 {
+		t.Error("Expected non-empty test limits")
+	}
+}
+
+func TestLoadTestLimitsFromFile(t *testing.T) {
+	// Test loading from specific file
+	packageDir, err := getPackageDir()
+	if err != nil {
+		t.Fatalf("Failed to get package directory: %v", err)
+	}
+
+	filePath := filepath.Join(packageDir, "test_limits.json")
+	limits, err := LoadTestLimitsFromFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to load test limits from file: %v", err)
+	}
+
+	if limits == nil {
+		t.Fatal("Expected test limits but got nil")
+	}
+
+	// Test with non-existent file
+	_, err = LoadTestLimitsFromFile("/nonexistent/file.json")
+	if err == nil {
+		t.Error("Expected error for non-existent file")
+	}
+}
+
+func TestGetTestConfig(t *testing.T) {
+	limits, err := LoadTestLimits()
+	if err != nil {
+		t.Fatalf("Failed to load test limits: %v", err)
+	}
+
+	// Test valid configuration
+	config, err := limits.GetTestConfig("BM.GPU.H100.8", "gid_index_check")
+	if err != nil {
+		t.Errorf("Failed to get test config: %v", err)
+	}
+
+	if config == nil {
+		t.Fatal("Expected test config but got nil")
+	}
+
+	if !config.Enabled {
+		t.Error("Expected GID index check to be enabled")
+	}
+
+	if config.TestCategory != "LEVEL_1" {
+		t.Errorf("Expected test category 'LEVEL_1', got '%s'", config.TestCategory)
+	}
+
+	// Test invalid shape
+	_, err = limits.GetTestConfig("INVALID.SHAPE", "gid_index_check")
+	if err == nil {
+		t.Error("Expected error for invalid shape")
+	}
+
+	// Test invalid test type
+	_, err = limits.GetTestConfig("BM.GPU.H100.8", "invalid_test")
+	if err == nil {
+		t.Error("Expected error for invalid test type")
+	}
+}
+
+func TestIsTestEnabled(t *testing.T) {
+	limits, err := LoadTestLimits()
+	if err != nil {
+		t.Fatalf("Failed to load test limits: %v", err)
+	}
+
+	// Test enabled test
+	enabled, err := limits.IsTestEnabled("BM.GPU.H100.8", "gid_index_check")
+	if err != nil {
+		t.Errorf("Failed to check if test is enabled: %v", err)
+	}
+	if !enabled {
+		t.Error("Expected GID index check to be enabled for H100")
+	}
+
+	// Test disabled test
+	enabled, err = limits.IsTestEnabled("BM.GPU.B200.8", "gid_index_check")
+	if err != nil {
+		t.Errorf("Failed to check if test is enabled: %v", err)
+	}
+	if enabled {
+		t.Error("Expected GID index check to be disabled for B200")
+	}
+
+	// Test invalid shape
+	_, err = limits.IsTestEnabled("INVALID.SHAPE", "gid_index_check")
+	if err == nil {
+		t.Error("Expected error for invalid shape")
+	}
+}
+
+func TestGetThresholdForTest(t *testing.T) {
+	limits, err := LoadTestLimits()
+	if err != nil {
+		t.Fatalf("Failed to load test limits: %v", err)
+	}
+
+	// Test GID index threshold (array)
+	threshold, err := limits.GetThresholdForTest("BM.GPU.H100.8", "gid_index_check")
+	if err != nil {
+		t.Errorf("Failed to get GID index threshold: %v", err)
+	}
+	if threshold == nil {
+		t.Error("Expected non-nil threshold")
+	}
+
+	// Verify it's an array
+	if thresholdArray, ok := threshold.([]interface{}); ok {
+		if len(thresholdArray) != 4 {
+			t.Errorf("Expected 4 threshold values, got %d", len(thresholdArray))
+		}
+	} else {
+		t.Error("Expected threshold to be an array")
+	}
+
+	// Test RX discards threshold (number)
+	threshold, err = limits.GetThresholdForTest("BM.GPU.H100.8", "rx_discards_check")
+	if err != nil {
+		t.Errorf("Failed to get RX discards threshold: %v", err)
+	}
+	if thresholdNum, ok := threshold.(float64); ok {
+		if thresholdNum != 100 {
+			t.Errorf("Expected RX discards threshold 100, got %v", thresholdNum)
+		}
+	} else {
+		t.Error("Expected threshold to be a number")
+	}
+
+	// Test SRAM error threshold (object)
+	threshold, err = limits.GetThresholdForTest("BM.GPU.H100.8", "sram_error_check")
+	if err != nil {
+		t.Errorf("Failed to get SRAM error threshold: %v", err)
+	}
+	if thresholdObj, ok := threshold.(map[string]interface{}); ok {
+		if uncorrectable, exists := thresholdObj["uncorrectable"]; exists {
+			if uncorrectable.(float64) != 10 {
+				t.Errorf("Expected uncorrectable threshold 10, got %v", uncorrectable)
+			}
+		} else {
+			t.Error("Expected uncorrectable field in SRAM threshold")
+		}
+	} else {
+		t.Error("Expected threshold to be an object")
+	}
+
+	// Test disabled test
+	_, err = limits.GetThresholdForTest("BM.GPU.B200.8", "gid_index_check")
+	if err == nil {
+		t.Error("Expected error for disabled test")
+	}
+
+	// Test invalid test type
+	_, err = limits.GetThresholdForTest("BM.GPU.H100.8", "invalid_test")
+	if err == nil {
+		t.Error("Expected error for invalid test type")
+	}
+}
+
+func TestGetAvailableShapes(t *testing.T) {
+	limits, err := LoadTestLimits()
+	if err != nil {
+		t.Fatalf("Failed to load test limits: %v", err)
+	}
+
+	shapes := limits.GetAvailableShapes()
+	if len(shapes) != 2 {
+		t.Errorf("Expected 2 shapes, got %d", len(shapes))
+	}
+
+	expectedShapes := map[string]bool{
+		"BM.GPU.H100.8": false,
+		"BM.GPU.B200.8": false,
+	}
+
+	for _, shape := range shapes {
+		if _, exists := expectedShapes[shape]; !exists {
+			t.Errorf("Unexpected shape: %s", shape)
+		} else {
+			expectedShapes[shape] = true
+		}
+	}
+
+	// Verify all expected shapes were found
+	for shape, found := range expectedShapes {
+		if !found {
+			t.Errorf("Expected shape %s not found", shape)
+		}
+	}
+}
+
+func TestGetEnabledTests(t *testing.T) {
+	limits, err := LoadTestLimits()
+	if err != nil {
+		t.Fatalf("Failed to load test limits: %v", err)
+	}
+
+	// Test H100 shape (all tests enabled)
+	enabledTests, err := limits.GetEnabledTests("BM.GPU.H100.8")
+	if err != nil {
+		t.Errorf("Failed to get enabled tests: %v", err)
+	}
+	if len(enabledTests) != 3 {
+		t.Errorf("Expected 3 enabled tests for H100, got %d", len(enabledTests))
+	}
+
+	expectedTests := map[string]bool{
+		"gid_index_check":   false,
+		"rx_discards_check": false,
+		"sram_error_check":  false,
+	}
+
+	for _, test := range enabledTests {
+		if _, exists := expectedTests[test]; !exists {
+			t.Errorf("Unexpected enabled test: %s", test)
+		} else {
+			expectedTests[test] = true
+		}
+	}
+
+	// Test B200 shape (all tests disabled)
+	enabledTests, err = limits.GetEnabledTests("BM.GPU.B200.8")
+	if err != nil {
+		t.Errorf("Failed to get enabled tests: %v", err)
+	}
+	if len(enabledTests) != 0 {
+		t.Errorf("Expected 0 enabled tests for B200, got %d", len(enabledTests))
+	}
+
+	// Test invalid shape
+	_, err = limits.GetEnabledTests("INVALID.SHAPE")
+	if err == nil {
+		t.Error("Expected error for invalid shape")
+	}
+}
+
+func TestPackageHelperFunctions(t *testing.T) {
+	// Test getPackageDir
+	dir, err := getPackageDir()
+	if err != nil {
+		t.Errorf("Failed to get package directory: %v", err)
+	}
+	if dir == "" {
+		t.Error("Expected non-empty package directory")
+	}
+
+	// Test getDefaultConfigPath
+	path, err := getDefaultConfigPath()
+	if err != nil {
+		t.Errorf("Failed to get default config path: %v", err)
+	}
+	if path == "" {
+		t.Error("Expected non-empty config path")
+	}
+	if !filepath.IsAbs(path) {
+		t.Error("Expected absolute config path")
+	}
+}
+
+func TestJSONStructureParsing(t *testing.T) {
+	limits, err := LoadTestLimits()
+	if err != nil {
+		t.Fatalf("Failed to load test limits: %v", err)
+	}
+
+	// Verify the JSON structure was parsed correctly
+	if limits.TestLimits == nil {
+		t.Fatal("Expected test limits map but got nil")
+	}
+
+	// Check H100 configuration exists
+	h100Config, exists := limits.TestLimits["BM.GPU.H100.8"]
+	if !exists {
+		t.Fatal("Expected BM.GPU.H100.8 configuration")
+	}
+
+	// Check test configurations
+	gidConfig, exists := h100Config["gid_index_check"]
+	if !exists {
+		t.Error("Expected gid_index_check configuration")
+	} else {
+		if !gidConfig.Enabled {
+			t.Error("Expected gid_index_check to be enabled")
+		}
+		if gidConfig.TestCategory != "LEVEL_1" {
+			t.Errorf("Expected test category LEVEL_1, got %s", gidConfig.TestCategory)
+		}
+	}
+
+	rxConfig, exists := h100Config["rx_discards_check"]
+	if !exists {
+		t.Error("Expected rx_discards_check configuration")
+	} else {
+		if !rxConfig.Enabled {
+			t.Error("Expected rx_discards_check to be enabled")
+		}
+	}
+
+	sramConfig, exists := h100Config["sram_error_check"]
+	if !exists {
+		t.Error("Expected sram_error_check configuration")
+	} else {
+		if !sramConfig.Enabled {
+			t.Error("Expected sram_error_check to be enabled")
+		}
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,4 +1,4 @@
-package Utils
+package utils
 
 import "strconv"
 

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import "testing"
+
+func TestIsInt(t *testing.T) {
+	// Test valid integers
+	validInts := []string{"0", "1", "42", "-1", "-42", "2147483647", "-2147483648"}
+	for _, input := range validInts {
+		if !IsInt(input) {
+			t.Errorf("IsInt(%q) = false, expected true", input)
+		}
+	}
+
+	// Test invalid integers
+	invalidInts := []string{"", "abc", "1.5", "1a", "a1", " 1", "1 ", "1.0", "++1", "--1"}
+	for _, input := range invalidInts {
+		if IsInt(input) {
+			t.Errorf("IsInt(%q) = true, expected false", input)
+		}
+	}
+}


### PR DESCRIPTION
Results:
`[opc@bio-2347xlg00f oci-dr-hpc-v2]$ oci-dr-hpc-v2 level1 --test rx_discards_check
INFO: 2025/07/07 14:54:13 root.go:initConfig:122: Using config file:/etc/oci-dr-hpc.yaml
INFO: 2025/07/07 14:54:13 level1.go:func2:25: Starting Level 1 diagnostic tests
INFO: 2025/07/07 14:54:13 level1.go:runSpecificTests:144: Running specific tests: [rx_discards_check]
INFO: 2025/07/07 14:54:13 level1.go:runSpecificTests:151: Running test: rx_discards_check
INFO: 2025/07/07 14:54:13 rx_discards_check.go:RunRXDiscardsCheck:145: === RX Discards Health Check ===
INFO: 2025/07/07 14:54:13 rx_discards_check.go:RunRXDiscardsCheck:148: Health check is in progress...
INFO: 2025/07/07 14:54:13 rx_discards_check.go:runRXDiscardsCheck:106: Running RX discards check with threshold:100
INFO: 2025/07/07 14:54:13 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma0
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma1
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma2
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma3
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma4
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma5
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma6
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma7
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma8
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma9
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma10
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma11
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma12
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma13
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma14
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma15
INFO: 2025/07/07 14:54:14 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:166: RX Discards Check results:
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:167: [
  {
    "rx_discards": {
      "device": "rdma0",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma1",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma2",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma3",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma4",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma5",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma6",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma7",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma8",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma9",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma10",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma11",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma12",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma13",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma14",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma15",
      "status": "PASS"
    }
  }
]
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma0: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma1: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma2: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma3: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma4: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma5: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma6: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma7: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma8: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma9: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma10: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma11: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma12: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma13: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma14: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma15: PASS
INFO: 2025/07/07 14:54:14 rx_discards_check.go:RunRXDiscardsCheck:190: RX Discards Check: PASS - All interfaces passed
┌─────────────────────────────────────────────────────────────────┐
│                    DIAGNOSTIC TEST RESULTS                     │
├─────────────────────────────────────────────────────────────────┤
│ TEST NAME              │ STATUS │ DETAILS                     │
├─────────────────────────────────────────────────────────────────┤
│ Network RX Discards    │ ✅      │ ✅ Interfaces: 16          │
└─────────────────────────────────────────────────────────────────┘

=== Test Summary ===
Total tests: 1
Passed: 1
Failed: 0
✅ All tests passed!
INFO: 2025/07/07 14:54:14 level1.go:runSpecificTests:197: Selected Level 1 tests completed successfully

✅ All selected Level 1 diagnostic tests passed successfully!
[opc@bio-2347xlg00f oci-dr-hpc-v2]$ oci-dr-hpc-v2 level1 --test rx_discards_check`


`[opc@bio-2347xlg00f oci-dr-hpc-v2]$ OCI_DR_HPC_LOGGING_LEVEL=SILENT oci-dr-hpc-v2 level1 --test rx_discards_check -o json
{
  "localhost": {
    "network_rx_discards": [
      {
        "interface_count": 16,
        "status": "PASS"
      }
    ]
  }
}
[opc@bio-2347xlg00f oci-dr-hpc-v2]$`


Failure result:
`[opc@bio-2347xlg00f oci-dr-hpc-v2]$ oci-dr-hpc-v2 level1 --test rx_discards_check
INFO: 2025/07/07 15:01:54 root.go:initConfig:122: Using config file:/etc/oci-dr-hpc.yaml
INFO: 2025/07/07 15:01:54 level1.go:func2:25: Starting Level 1 diagnostic tests
INFO: 2025/07/07 15:01:54 level1.go:runSpecificTests:144: Running specific tests: [rx_discards_check]
INFO: 2025/07/07 15:01:54 level1.go:runSpecificTests:151: Running test: rx_discards_check
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:145: === RX Discards Health Check ===
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:148: Health check is in progress...
INFO: 2025/07/07 15:01:54 rx_discards_check.go:runRXDiscardsCheck:106: Running RX discards check with threshold:100
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma099
ERROR: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:283: ethtool command failed: exit status 1
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma1
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma2
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma3
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma4
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma5
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma6
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma7
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma8
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma9
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma10
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma11
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma12
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma13
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma14
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:259: Running ethtool -S for interface: rdma15
INFO: 2025/07/07 15:01:54 os_commands.go:RunEthtoolStats:288: ethtool command completed successfully
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:166: RX Discards Check results:
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:167: [
  {
    "rx_discards": {
      "device": "rdma099",
      "status": "FAIL"
    }
  },
  {
    "rx_discards": {
      "device": "rdma1",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma2",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma3",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma4",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma5",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma6",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma7",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma8",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma9",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma10",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma11",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma12",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma13",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma14",
      "status": "PASS"
    }
  },
  {
    "rx_discards": {
      "device": "rdma15",
      "status": "PASS"
    }
  }
]
ERROR: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:175: Interface rdma099: FAIL
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma1: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma2: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma3: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma4: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma5: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma6: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma7: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma8: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma9: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma10: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma11: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma12: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma13: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma14: PASS
INFO: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:178: Interface rdma15: PASS
ERROR: 2025/07/07 15:01:54 rx_discards_check.go:RunRXDiscardsCheck:185: RX Discards Check: FAIL -RX discards check failed for 1 out of 16 interfaces
ERROR: 2025/07/07 15:01:54 level1.go:runSpecificTests:153: Test rx_discards_check failed: RX discards check failed for 1 out of 16 interfaces
┌─────────────────────────────────────────────────────────────────┐
│                    DIAGNOSTIC TEST RESULTS                     │
├─────────────────────────────────────────────────────────────────┤
│ TEST NAME              │ STATUS │ DETAILS                     │
├─────────────────────────────────────────────────────────────────┤
│ Network RX Discards    │ ❌      │ ❌ Failed: 1/1          │
└─────────────────────────────────────────────────────────────────┘

=== Test Summary ===
Total tests: 1
Passed: 0
Failed: 1
Failed tests: [network_rx_discards]
❌ 1 test(s) failed
ERROR: 2025/07/07 15:01:54 level1.go:runSpecificTests:188: Selected Level 1 tests completed with 1 failures: [rx_discards_check]

❌ Level 1 diagnostic tests failed: 1 out of 1 tests failed
Failed tests: rx_discards_check
Error: diagnostic tests failed
diagnostic tests failed
[opc@bio-2347xlg00f oci-dr-hpc-v2]$`