### PR TITLE
Adding new test: missing_interface_error

### DIFF
--- a/cmd/level1.go
+++ b/cmd/level1.go
@@ -83,6 +83,7 @@ func runAllLevel1Tests() error {
 		{"cdfp_cable_check", level1_tests.RunCDFPCableCheck},
 		{"fabricmanager_check", level1_tests.RunFabricManagerCheck},
 		{"hca_error_check", level1_tests.RunHCAErrorCheck},
+		{"missing_interface_check", level1_tests.RunMissingInterfaceCheck},
 	}
 
 	var failedTests []string
@@ -156,6 +157,7 @@ func runSpecificTests(testFilter string) error {
 		{"cdfp_cable_check", "Check CDFP cable connections between GPUs", level1_tests.RunCDFPCableCheck},
 		{"fabricmanager_check", "Check if nvidia-fabricmanager service is running", level1_tests.RunFabricManagerCheck},
 		{"hca_error_check", "Check for MLX5 HCA fatal errors in system logs", level1_tests.RunHCAErrorCheck},
+		{"missing_interface_check", "Check for missing PCIe interfaces (revision ff)", level1_tests.RunMissingInterfaceCheck},
 	}
 
 	// If testFilter is empty, show available tests

--- a/configs/recommendations.json
+++ b/configs/recommendations.json
@@ -529,6 +529,32 @@
           "dmesg -T | tail -50"
         ]
       }
+    },
+    "missing_interface_check": {
+      "fail": {
+        "type": "critical",
+        "fault_code": "HPCGPU-0012-0001",
+        "issue": "Missing PCIe interfaces detected ({missing_count} interface(s) with revision 'ff'). This typically indicates failed or missing hardware components that may cause system instability.",
+        "suggestion": "Reboot the node. If one or more components show up missing within a day, return to OCI. If it fails to reboot, terminate and send it to OCI.",
+        "commands": [
+          "lspci | grep -i 'rev ff'",
+          "dmesg | grep -i pci"
+        ],
+        "references": [
+          "https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm",
+          "https://www.kernel.org/doc/Documentation/PCI/pci.txt",
+          "https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/managinginstances.htm"
+        ]
+      },
+      "pass": {
+        "type": "info",
+        "issue": "Missing interface check passed - no missing PCIe interfaces detected",
+        "suggestion": "All PCIe interfaces are properly detected and functioning correctly",
+        "commands": [
+          "lspci",
+          "lspci -tv"
+        ]
+      }
     }
   },
   "summary_templates": {

--- a/internal/level1_tests/missing_interface_check.go
+++ b/internal/level1_tests/missing_interface_check.go
@@ -1,0 +1,128 @@
+package level1_tests
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/oracle/oci-dr-hpc-v2/internal/test_limits"
+
+	"github.com/oracle/oci-dr-hpc-v2/internal/executor"
+	"github.com/oracle/oci-dr-hpc-v2/internal/logger"
+	"github.com/oracle/oci-dr-hpc-v2/internal/reporter"
+)
+
+// MissingInterfaceCheckTestConfig represents the config needed to run this test
+type MissingInterfaceCheckTestConfig struct {
+	IsEnabled bool   `json:"enabled"`
+	Shape     string `json:"shape"`
+	Threshold int    `json:"threshold"`
+}
+
+// Gets test config needed to run this test
+func getMissingInterfaceCheckTestConfig() (*MissingInterfaceCheckTestConfig, error) {
+	// Get shape from IMDS
+	shape, err := executor.GetCurrentShape()
+	if err != nil {
+		return nil, err
+	}
+
+	// Load configuration from test_limits.json
+	limits, err := test_limits.LoadTestLimits()
+	if err != nil {
+		return nil, err
+	}
+
+	// Result
+	missingInterfaceCheckTestConfig := &MissingInterfaceCheckTestConfig{
+		IsEnabled: false,
+		Shape:     shape,
+		Threshold: 0,
+	}
+
+	enabled, err := limits.IsTestEnabled(shape, "missing_interface_check")
+	if err != nil {
+		return nil, err
+	}
+	missingInterfaceCheckTestConfig.IsEnabled = enabled
+
+	// Get threshold value
+	if enabled {
+		threshold, err := limits.GetThresholdForTest(shape, "missing_interface_check")
+		if err != nil {
+			return nil, err
+		}
+
+		if thresholdFloat, ok := threshold.(float64); ok {
+			missingInterfaceCheckTestConfig.Threshold = int(thresholdFloat)
+		}
+	}
+
+	return missingInterfaceCheckTestConfig, nil
+}
+
+func parseLspciForMissingInterfaces(output string) (int, error) {
+	lines := strings.Split(output, "\n")
+	missingCount := 0
+
+	for _, line := range lines {
+		lowerLine := strings.ToLower(line)
+		if strings.Contains(lowerLine, "rev ff") {
+			missingCount++
+		}
+	}
+
+	return missingCount, nil
+}
+
+func RunMissingInterfaceCheck() error {
+	logger.Info("=== Missing Interface Check ===")
+	testConfig, err := getMissingInterfaceCheckTestConfig()
+	if err != nil {
+		return err
+	}
+
+	if !testConfig.IsEnabled {
+		errorStatement := fmt.Sprintf("Test not applicable for this shape %s", testConfig.Shape)
+		logger.Info(errorStatement)
+		return errors.New(errorStatement)
+	}
+
+	logger.Info("Starting missing interface check...")
+	logger.Info("This will take about 1 minute to complete.")
+	rep := reporter.GetReporter()
+
+	// Run the lspci command to check for missing interfaces
+	logger.Info("Checking for missing PCIe interfaces...")
+	result, err := executor.RunLspci()
+	if err != nil {
+		logger.Error("Failed to run lspci command:", err)
+		logger.Info("Missing Interface Check: FAIL - Could not run lspci command")
+		rep.AddMissingInterfaceResult("FAIL", 0, fmt.Errorf("could not run lspci command: %v", err))
+		return fmt.Errorf("could not run lspci command: %v", err)
+	}
+
+	// Parse the lspci output for missing interfaces
+	missingCount, err := parseLspciForMissingInterfaces(result.Output)
+	if err != nil {
+		logger.Error("Failed to parse lspci output:", err)
+		logger.Info("Missing Interface Check: FAIL - Could not parse lspci output")
+		rep.AddMissingInterfaceResult("FAIL", 0, fmt.Errorf("could not parse lspci output: %v", err))
+		return fmt.Errorf("could not parse lspci output: %v", err)
+	}
+
+	// Check if missing interfaces exceed threshold
+	if missingCount > testConfig.Threshold {
+		logger.Error(fmt.Sprintf("Found %d missing interface(s), exceeds threshold of %d", missingCount, testConfig.Threshold))
+		logger.Info("Missing Interface Check: FAIL - Missing PCIe interfaces detected")
+		err = fmt.Errorf("found %d missing PCIe interfaces, exceeds threshold of %d", missingCount, testConfig.Threshold)
+		rep.AddMissingInterfaceResult("FAIL", missingCount, err)
+		return err
+	}
+
+	// No missing interfaces found - check passes
+	logger.Info("No missing interfaces found")
+	logger.Info("Missing Interface Check: PASS")
+	rep.AddMissingInterfaceResult("PASS", 0, nil)
+	return nil
+}

--- a/internal/recommender/config.go
+++ b/internal/recommender/config.go
@@ -171,6 +171,7 @@ func applyVariableSubstitution(template string, testResult TestResult) string {
 	result = strings.ReplaceAll(result, "{failed_interfaces}", fmt.Sprintf("%s", testResult.FailedInterfaces))
 	result = strings.ReplaceAll(result, "{max_uncorrectable}", fmt.Sprintf("%d", testResult.MaxUncorrectable))
 	result = strings.ReplaceAll(result, "{max_correctable}", fmt.Sprintf("%d", testResult.MaxCorrectable))
+	result = strings.ReplaceAll(result, "{missing_count}", fmt.Sprintf("%d", testResult.MissingCount))
 	result = strings.ReplaceAll(result, "{eth0_present}", fmt.Sprintf("%t", testResult.Eth0Present))
 
 	// Replace GPU mode check specific variables

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -235,6 +235,14 @@ func TestReporter_AllResultTypes(t *testing.T) {
 			resultKey:  "hca_error_check",
 			wantStatus: "PASS",
 		},
+		{
+			name: "Missing Interface Check Result",
+			addFunc: func(r *Reporter) {
+				r.AddMissingInterfaceResult("PASS", 0, nil)
+			},
+			resultKey:  "missing_interface_check",
+			wantStatus: "PASS",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/test_limits/test_limits.json
+++ b/internal/test_limits/test_limits.json
@@ -117,6 +117,11 @@
       "hca_error_check": {
         "enabled": true,
         "test_category": "LEVEL_1"
+      },
+      "missing_interface_check": {
+        "enabled": true,
+        "test_category": "LEVEL_1",
+        "threshold": 0
       }
     },
     "BM.GPU.B200.8": {
@@ -183,6 +188,11 @@
       "hca_error_check": {
         "enabled": false,
         "test_category": "LEVEL_1"
+      },
+      "missing_interface_check": {
+        "enabled": false,
+        "test_category": "LEVEL_1",
+        "threshold": 0
       }      
     },
     "BM.GPU.GB200.4": {
@@ -259,6 +269,11 @@
       "hca_error_check": {
         "enabled": false,
         "test_category": "LEVEL_1"
+      },
+      "missing_interface_check": {
+        "enabled": false,
+        "test_category": "LEVEL_1",
+        "threshold": 0
       }      
     }
   }

--- a/internal/test_limits/test_limits_test.go
+++ b/internal/test_limits/test_limits_test.go
@@ -284,8 +284,8 @@ func TestGetEnabledTests(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get enabled tests: %v", err)
 	}
-	if len(enabledTests) != 18 {
-		t.Errorf("Expected 18 enabled tests for H100, got %d", len(enabledTests))
+	if len(enabledTests) != 19 {
+		t.Errorf("Expected 19 enabled tests for H100, got %d", len(enabledTests))
 	}
 
 	expectedTests := map[string]bool{
@@ -307,6 +307,7 @@ func TestGetEnabledTests(t *testing.T) {
 		"cdfp_cable_check":     false,
 		"fabricmanager_check":  false,
 		"hca_error_check":      false,
+		"missing_interface_check": false,
 	}
 
 	for _, test := range enabledTests {

--- a/scripts/BM.GPU.H100.8/missing_interface_check.py
+++ b/scripts/BM.GPU.H100.8/missing_interface_check.py
@@ -1,0 +1,60 @@
+"""
+# This script checks for missing PCIe interfaces on a specified host by running the `lspci` command
+# and parsing the output for any devices with revision 'ff' (indicating missing/failed devices).
+# It returns a JSON object indicating the status of the missing interface check, which can be
+# either "PASS" or "FAIL". The script is designed to be run in a HPC environment where the user
+# has the necessary permissions to run `lspci`.
+"""
+
+import shlex
+import subprocess
+import json
+
+# Function to run command and capture output
+def run_cmd(cmd):
+    cmd_split = shlex.split(cmd)
+    try:
+        results = subprocess.run(cmd_split, shell=False, stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT, check=True, encoding='utf8')
+        output = results.stdout.strip()
+    except subprocess.CalledProcessError as e_process_error:
+        return f"Error: {cmd} {e_process_error.returncode} {e_process_error.output}"
+    return output
+
+# Function to parse lspci output and check for missing interfaces
+def parse_missing_interface_results(lspci_result="0"):
+    result = {
+         "missing_interface":
+            {"status": "PASS", "missing_count": 0}
+    }
+    
+    try:
+        missing_count = int(lspci_result.strip())
+        result["missing_interface"]["missing_count"] = missing_count
+        
+        if missing_count > 0:
+            result["missing_interface"]["status"] = "FAIL"
+            
+    except (ValueError, AttributeError):
+        # If we can't parse the count or get an error, treat as failure
+        result["missing_interface"]["status"] = "FAIL"
+        result["missing_interface"]["error"] = "Unable to parse missing interface count"
+        
+    return result
+
+# Function to run the missing interface check
+def run_missing_interface_check():
+    """ Run missing interface check - checking for PCIe devices with revision 'ff' """
+    cmd = "lspci | grep -i 'rev ff' | wc -l"
+    lspci_result = run_cmd(cmd)
+    return parse_missing_interface_results(lspci_result)
+
+# Main function to call run_missing_interface_check and parse the results
+def main():
+    print("Health check is in progress and the result will be provided within 1 minute.")
+    result = run_missing_interface_check()
+    print(json.dumps(result, indent=2))
+
+# Run the main function
+if __name__ == "__main__":
+    main()

--- a/scripts/BM.GPU.H100.8/missing_interface_check.sh
+++ b/scripts/BM.GPU.H100.8/missing_interface_check.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Missing Interface Check Script
+# This script checks for missing PCIe interfaces by looking for devices with revision 'ff'
+# It outputs either "PASS" if no missing interfaces are found, or "FAIL" if any are detected
+
+echo "Starting missing interface health check..."
+echo "This will take about 1 minute to complete."
+
+# Run the lspci command to check for missing interfaces
+# lspci shows PCI devices, grep filters for revision 'ff' (missing/failed devices), wc counts them
+echo "Checking for missing PCIe interfaces..."
+missing_count=$(lspci | grep -i 'rev ff' | wc -l 2>&1)
+
+# Check if the command failed
+if [ $? -ne 0 ]; then
+    echo "Error: Could not run lspci command"
+    jq -n '{"missing_interface": {"status": "FAIL", "error": "Command failed"}}'
+    exit 1
+fi
+
+# Start with PASS status - we'll change to FAIL if we find missing interfaces
+status="PASS"
+
+# Check if any missing interfaces were found
+if [ "$missing_count" -gt 0 ]; then
+    echo "Found $missing_count missing interface(s)"
+    status="FAIL"
+else
+    echo "No missing interfaces found"
+fi
+
+# Print the final result
+jq -n \
+      --arg status "$status" \
+      --argjson missing_count "$missing_count" \
+      '{
+        "missing_interface": {
+          "status": $status,
+          "missing_count": $missing_count
+        }
+      }'


### PR DESCRIPTION
⏺ Add Missing Interface Check for PCIe Device Validation

  Summary

  Adds missing_interface_check health check to detect missing/failed
   PCIe interfaces by identifying devices with revision 'ff' - a key
   indicator of hardware failures in HPC GPU clusters.

  What's New

  - New Test: Detects PCIe devices with revision 'ff' using lspci
  command
  - Fault Code: HPCGPU-0012-0001 for tracking and escalation
  - Configuration: Enabled for BM.GPU.H100.8 (threshold: 0),
  disabled for other shapes
  - Integration: Full reporter, recommender, and test framework
  support

  Files Modified

  - Core implementation: missing_interface_check.go (128 lines)
  - Configuration: test_limits.json, recommendations.json
  - Integration: reporter.go, recommender.go, level1.go
  - Testing: Updated 3 test files with minimal changes
  - Scripts: Python and shell versions for automation

  Key Features

  - Detection: lspci | grep -i 'rev ff' with configurable thresholds
  - Output: JSON, table, and friendly formats with missing count
  details
  - Recommendations: Automated troubleshooting steps and escalation
  procedures
  - Compatibility: No breaking changes, follows existing patterns