### PR TITLE
Adding row remap error check 

### DIFF
--- a/cmd/level1.go
+++ b/cmd/level1.go
@@ -86,6 +86,7 @@ func runAllLevel1Tests() error {
 		{"missing_interface_check", level1_tests.RunMissingInterfaceCheck},
 		{"gpu_xid_check", level1_tests.RunGPUXIDCheck},
 		{"max_acc_check", level1_tests.RunMaxAccCheck},
+		{"row_remap_error_check", level1_tests.RunRowRemapErrorCheck},
 	}
 
 	var failedTests []string
@@ -162,6 +163,7 @@ func runSpecificTests(testFilter string) error {
 		{"missing_interface_check", "Check for missing PCIe interfaces (revision ff)", level1_tests.RunMissingInterfaceCheck},
 		{"gpu_xid_check", "Check for NVIDIA GPU XID errors in system logs", level1_tests.RunGPUXIDCheck},
 		{"max_acc_check", "Check MAX_ACC_OUT_READ and ADVANCED_PCI_SETTINGS configuration", level1_tests.RunMaxAccCheck},
+		{"row_remap_error_check", "Check for GPU row remap errors using nvidia-smi", level1_tests.RunRowRemapErrorCheck},
 	}
 
 	// If testFilter is empty, show available tests

--- a/configs/recommendations.json
+++ b/configs/recommendations.json
@@ -599,7 +599,7 @@
         ]
       }
     },
-    "max_acc_check": {
+     "max_acc_check": {
       "fail": {
         "type": "critical",
         "fault_code": "HPCGPU-0017-0001",
@@ -627,6 +627,33 @@
           "sudo /usr/bin/mlxconfig -d <pci_device> query",
           "ibstat",
           "rdma link show"
+        ]
+      }
+    },
+    "row_remap_error_check": {
+      "fail": {
+        "type": "critical",
+        "fault_code": "HPCGPU-0013-0001",
+        "issue": "GPU row remap errors detected ({failure_count} GPU(s) with failures). Row remap errors indicate GPU memory failures that can cause data corruption, computation errors, or system instability.",
+        "suggestion": "Reboot the host or reset the GPUs. Investigate GPU memory health immediately. Consider replacing affected GPUs or terminating the instance if memory errors persist. Monitor for additional memory-related errors.",
+        "commands": [
+          "nvidia-smi --query-remapped-rows=gpu_bus_id,remapped_rows.failure --format=csv,noheader",
+          "nvidia-smi --query-gpu=name,memory.total,memory.free,memory.used --format=csv",
+          "nvidia-smi -q -d MEMORY",
+          "dmesg | grep -i 'memory\\|ecc\\|error'",
+          "nvidia-smi --query-gpu=ecc.errors.corrected.total,ecc.errors.uncorrected.total --format=csv"
+        ],
+        "references": [
+          "https://docs.nvidia.com/gameworks/content/developertools/desktop/nvidia-smi.htm"
+        ]
+      },
+      "pass": {
+        "type": "info",
+        "issue": "No GPU row remap errors detected - all GPU memory appears healthy",
+        "suggestion": "GPU memory is functioning correctly without row remap failures. Continue periodic monitoring of GPU memory health.",
+        "commands": [
+          "nvidia-smi --query-remapped-rows=gpu_bus_id,remapped_rows.failure --format=csv,noheader",
+          "nvidia-smi --query-gpu=name,memory.total,memory.free --format=csv"
         ]
       }
     }

--- a/internal/level1_tests/row_remap_error_check.go
+++ b/internal/level1_tests/row_remap_error_check.go
@@ -1,0 +1,240 @@
+package level1_tests
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/oracle/oci-dr-hpc-v2/internal/executor"
+	"github.com/oracle/oci-dr-hpc-v2/internal/logger"
+	"github.com/oracle/oci-dr-hpc-v2/internal/reporter"
+	"github.com/oracle/oci-dr-hpc-v2/internal/shapes"
+	"github.com/oracle/oci-dr-hpc-v2/internal/test_limits"
+)
+
+// RowRemapErrorCheckTestConfig represents the config needed to run this test
+type RowRemapErrorCheckTestConfig struct {
+	IsEnabled        bool   `json:"enabled"`
+	Shape            string `json:"shape"`
+	Threshold        int    `json:"threshold"`
+	NvidiaSMIVersion int    `json:"nvidia-smi-version"`
+}
+
+// Gets test config needed to run this test
+func getRowRemapErrorCheckTestConfig() (*RowRemapErrorCheckTestConfig, error) {
+	// Get shape from IMDS
+	shape, err := executor.GetCurrentShape()
+	if err != nil {
+		return nil, err
+	}
+
+	// Load configuration from test_limits.json
+	limits, err := test_limits.LoadTestLimits()
+	if err != nil {
+		return nil, err
+	}
+
+	// Result
+	rowRemapErrorCheckTestConfig := &RowRemapErrorCheckTestConfig{
+		IsEnabled:        false,
+		Shape:            shape,
+		Threshold:        0,
+		NvidiaSMIVersion: 550,
+	}
+
+	enabled, err := limits.IsTestEnabled(shape, "row_remap_error_check")
+	if err != nil {
+		return nil, err
+	}
+	rowRemapErrorCheckTestConfig.IsEnabled = enabled
+
+	// Get threshold configuration if available
+	threshold, err := limits.GetThresholdForTest(shape, "row_remap_error_check")
+	if err == nil {
+		// Parse threshold configuration from test_limits.json
+		switch v := threshold.(type) {
+		case map[string]interface{}:
+			// Get minimum-error threshold
+			if minError, ok := v["minimum-error"].(float64); ok {
+				rowRemapErrorCheckTestConfig.Threshold = int(minError)
+			}
+
+			// Get minimum-nvidia-smi-version
+			if minVersion, ok := v["minimum-nvidia-smi-version"].(float64); ok {
+				rowRemapErrorCheckTestConfig.NvidiaSMIVersion = int(minVersion)
+			}
+		}
+	}
+
+	return rowRemapErrorCheckTestConfig, nil
+}
+
+func parseRemappedRowsResults(output string, expectedBusIDs []string, threshold int) (int, []string, []string, error) {
+	lines := strings.Split(output, "\n")
+	foundBusIDs := make(map[string]bool)
+	var failedBusIDs []string
+	var missingBusIDs []string
+
+	// Create a map of expected bus IDs in lowercase for case insensitive comparison
+	expectedBusIDsMap := make(map[string]string)
+	for _, expectedID := range expectedBusIDs {
+		expectedBusIDsMap[strings.ToLower(expectedID)] = expectedID
+	}
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "Error:") {
+			continue
+		}
+
+		// Parse CSV format: gpu_bus_id, remapped_rows.failure
+		parts := strings.Split(line, ",")
+		if len(parts) < 2 {
+			continue
+		}
+
+		busID := strings.TrimSpace(parts[0])
+		failureCountStr := strings.TrimSpace(parts[1])
+
+		// Convert to standard PCI format (shapes.json uses 0000:xx:xx.x format)
+		if strings.HasPrefix(busID, "00000000:") {
+			busID = busID[8:] // Remove the first 8 characters
+			busID = "0000" + busID
+		}
+
+		// Normalize bus ID to lowercase for comparison
+		busIDLower := strings.ToLower(busID)
+
+		// Find the matching expected bus ID (case insensitive)
+		var matchedBusID string
+		if originalID, exists := expectedBusIDsMap[busIDLower]; exists {
+			matchedBusID = originalID
+		} else {
+			matchedBusID = busID // Use the original format if no match found
+		}
+
+		foundBusIDs[matchedBusID] = true
+
+		// Check if failure count exceeds threshold
+		failureCount, err := strconv.Atoi(failureCountStr)
+		if err != nil {
+			// If we can't parse the failure count, treat as failure
+			failedBusIDs = append(failedBusIDs, matchedBusID)
+			continue
+		}
+
+		if failureCount > threshold {
+			failedBusIDs = append(failedBusIDs, matchedBusID)
+		}
+	}
+
+	// Check for missing GPUs
+	for _, expectedID := range expectedBusIDs {
+		if !foundBusIDs[expectedID] {
+			missingBusIDs = append(missingBusIDs, expectedID)
+		}
+	}
+
+	return len(failedBusIDs), failedBusIDs, missingBusIDs, nil
+}
+
+func RunRowRemapErrorCheck() error {
+	logger.Info("=== Row Remap Error Check ===")
+	testConfig, err := getRowRemapErrorCheckTestConfig()
+	if err != nil {
+		return err
+	}
+
+	if !testConfig.IsEnabled {
+		errorStatement := fmt.Sprintf("Test not applicable for this shape %s", testConfig.Shape)
+		logger.Info(errorStatement)
+		return errors.New(errorStatement)
+	}
+
+	// Check nvidia-smi driver version first
+	driverVersion, err := executor.GetNvidiaSMIDriverVersion()
+	if err != nil {
+		logger.Error("Failed to get nvidia-smi driver version:", err)
+		logger.Info("Row Remap Error Check: FAIL - Could not determine nvidia-smi driver version")
+		rep := reporter.GetReporter()
+		rep.AddRowRemapResult("FAIL", fmt.Errorf("could not determine nvidia-smi driver version: %v", err), 0)
+		return fmt.Errorf("could not determine nvidia-smi driver version: %v", err)
+	}
+
+	if driverVersion < testConfig.NvidiaSMIVersion {
+		errorStatement := fmt.Sprintf("Not applicable for nvidia-smi driver : %d", driverVersion)
+		logger.Info(errorStatement)
+		rep := reporter.GetReporter()
+		rep.AddRowRemapResult(errorStatement, nil, 0)
+		return errors.New(errorStatement)
+	}
+
+	// Get expected GPU bus IDs from shapes configuration
+	shapeManager, err := shapes.GetDefaultShapeManager()
+	if err != nil {
+		logger.Error("Failed to load shapes configuration:", err)
+		logger.Info("Row Remap Error Check: FAIL - Could not load shapes configuration")
+		rep := reporter.GetReporter()
+		rep.AddRowRemapResult("FAIL", fmt.Errorf("could not load shapes configuration: %v", err), 0)
+		return fmt.Errorf("could not load shapes configuration: %v", err)
+	}
+
+	expectedBusIDs, err := shapeManager.GetGPUPCIAddresses(testConfig.Shape)
+	if err != nil {
+		logger.Error("Failed to get GPU PCI addresses for shape:", testConfig.Shape, err)
+		logger.Info("Row Remap Error Check: FAIL - Could not get expected GPU PCI addresses")
+		rep := reporter.GetReporter()
+		rep.AddRowRemapResult("FAIL", fmt.Errorf("could not get expected GPU PCI addresses: %v", err), 0)
+		return fmt.Errorf("could not get expected GPU PCI addresses: %v", err)
+	}
+
+	logger.Info("Starting row remap error check...")
+	logger.Info("This will take about 1 minute to complete.")
+	rep := reporter.GetReporter()
+
+	// Run the nvidia-smi remapped rows query
+	logger.Info("Checking for GPU row remap errors...")
+	result := executor.RunNvidiaSMIRemappedRowsQuery()
+	if !result.Available {
+		logger.Error("Failed to run nvidia-smi remapped rows query:", result.Error)
+		logger.Info("Row Remap Error Check: FAIL - Could not run nvidia-smi remapped rows query")
+		rep.AddRowRemapResult("FAIL", fmt.Errorf("could not run nvidia-smi remapped rows query: %s", result.Error), 0)
+		return fmt.Errorf("could not run nvidia-smi remapped rows query: %s", result.Error)
+	}
+
+	// Parse the nvidia-smi output for row remap failures
+	failureCount, failedBusIDs, missingBusIDs, err := parseRemappedRowsResults(result.Output, expectedBusIDs, testConfig.Threshold)
+	if err != nil {
+		logger.Error("Failed to parse remapped rows results:", err)
+		logger.Info("Row Remap Error Check: FAIL - Could not parse remapped rows results")
+		rep.AddRowRemapResult("FAIL", fmt.Errorf("could not parse remapped rows results: %v", err), 0)
+		return fmt.Errorf("could not parse remapped rows results: %v", err)
+	}
+
+	// Check for failures
+	if len(failedBusIDs) > 0 || len(missingBusIDs) > 0 {
+		if len(failedBusIDs) > 0 {
+			logger.Error("Found GPUs with row remap failures:")
+			for _, busID := range failedBusIDs {
+				logger.Error("GPU with failures:", busID)
+			}
+		}
+		if len(missingBusIDs) > 0 {
+			logger.Error("Missing expected GPUs:")
+			for _, busID := range missingBusIDs {
+				logger.Error("Missing GPU:", busID)
+			}
+		}
+		logger.Info("Row Remap Error Check: FAIL - Row remap errors or missing GPUs found")
+		err = fmt.Errorf("found %d GPU(s) with row remap failures, %d missing GPU(s)", len(failedBusIDs), len(missingBusIDs))
+		rep.AddRowRemapResult("FAIL", err, failureCount)
+		return err
+	}
+
+	// No failures found - check passes
+	logger.Info("No row remap errors found")
+	logger.Info("Row Remap Error Check: PASS")
+	rep.AddRowRemapResult("PASS", nil, 0)
+	return nil
+}

--- a/internal/level1_tests/row_remap_error_check_test.go
+++ b/internal/level1_tests/row_remap_error_check_test.go
@@ -1,0 +1,98 @@
+package level1_tests
+
+import (
+	"testing"
+)
+
+func TestParseRemappedRowsResults(t *testing.T) {
+	expectedBusIDs := []string{
+		"0000:0f:00.0",
+		"0000:2d:00.0",
+		"0000:44:00.0",
+	}
+
+	tests := []struct {
+		name         string
+		output       string
+		threshold    int
+		wantFailures int
+		wantFailed   []string
+		wantMissing  []string
+	}{
+		{
+			name: "no failures",
+			output: `00000000:0f:00.0, 0
+00000000:2d:00.0, 0
+00000000:44:00.0, 0`,
+			threshold:    0,
+			wantFailures: 0,
+			wantFailed:   []string{},
+			wantMissing:  []string{},
+		},
+		{
+			name: "one failure above threshold",
+			output: `00000000:0f:00.0, 5
+00000000:2d:00.0, 0
+00000000:44:00.0, 0`,
+			threshold:    0,
+			wantFailures: 1,
+			wantFailed:   []string{"0000:0f:00.0"},
+			wantMissing:  []string{},
+		},
+		{
+			name: "missing GPU",
+			output: `00000000:0f:00.0, 0
+00000000:2d:00.0, 0`,
+			threshold:    0,
+			wantFailures: 0,
+			wantFailed:   []string{},
+			wantMissing:  []string{"0000:44:00.0"},
+		},
+		{
+			name: "case insensitive matching",
+			output: `00000000:0F:00.0, 0
+00000000:2D:00.0, 1
+00000000:44:00.0, 0`,
+			threshold:    0,
+			wantFailures: 1,
+			wantFailed:   []string{"0000:2d:00.0"},
+			wantMissing:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failureCount, failedBusIDs, missingBusIDs, err := parseRemappedRowsResults(tt.output, expectedBusIDs, tt.threshold)
+			
+			if err != nil {
+				t.Errorf("parseRemappedRowsResults() error = %v", err)
+				return
+			}
+			
+			if failureCount != tt.wantFailures {
+				t.Errorf("parseRemappedRowsResults() failureCount = %v, want %v", failureCount, tt.wantFailures)
+			}
+			
+			if len(failedBusIDs) != len(tt.wantFailed) {
+				t.Errorf("parseRemappedRowsResults() failed count = %v, want %v", len(failedBusIDs), len(tt.wantFailed))
+			}
+			
+			if len(missingBusIDs) != len(tt.wantMissing) {
+				t.Errorf("parseRemappedRowsResults() missing count = %v, want %v", len(missingBusIDs), len(tt.wantMissing))
+			}
+			
+			for _, expected := range tt.wantFailed {
+				found := false
+				for _, actual := range failedBusIDs {
+					if actual == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("parseRemappedRowsResults() missing failed bus ID %v", expected)
+				}
+			}
+		})
+	}
+}

--- a/internal/recommender/config.go
+++ b/internal/recommender/config.go
@@ -172,6 +172,7 @@ func applyVariableSubstitution(template string, testResult TestResult) string {
 	result = strings.ReplaceAll(result, "{max_uncorrectable}", fmt.Sprintf("%d", testResult.MaxUncorrectable))
 	result = strings.ReplaceAll(result, "{max_correctable}", fmt.Sprintf("%d", testResult.MaxCorrectable))
 	result = strings.ReplaceAll(result, "{missing_count}", fmt.Sprintf("%d", testResult.MissingCount))
+	result = strings.ReplaceAll(result, "{failure_count}", fmt.Sprintf("%d", testResult.FailureCount))
 	result = strings.ReplaceAll(result, "{eth0_present}", fmt.Sprintf("%t", testResult.Eth0Present))
 
 	// Replace max_acc_check specific variables

--- a/internal/recommender/config_test.go
+++ b/internal/recommender/config_test.go
@@ -292,6 +292,7 @@ func TestApplyVariableSubstitution(t *testing.T) {
 		MaxUncorrectable:  5,
 		MaxCorrectable:    100,
 		FailedInterfaces:  "rdma2,rdma3",
+		FailureCount:      3,
 		Eth0Present:       true,
 	}
 
@@ -322,6 +323,10 @@ func TestApplyVariableSubstitution(t *testing.T) {
 		{
 			template: "Eth0 present: {eth0_present}",
 			expected: "Eth0 present: true",
+		},
+		{
+			template: "GPU failures: {failure_count}",
+			expected: "GPU failures: 3",
 		},
 		{
 			template: "No variables here",

--- a/internal/recommender/recommender_test.go
+++ b/internal/recommender/recommender_test.go
@@ -696,6 +696,16 @@ func TestSpecificTestTypes(t *testing.T) {
 			expectType: "critical",
 			expectTest: "missing_interface_check",
 		},
+		{
+			name: "Row Remap Error Check",
+			hostResult: HostResults{
+				RowRemapErrorCheck: []TestResult{
+					{Status: "FAIL", FailureCount: 2},
+				},
+			},
+			expectType: "critical",
+			expectTest: "row_remap_error_check",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -243,6 +243,14 @@ func TestReporter_AllResultTypes(t *testing.T) {
 			resultKey:  "missing_interface_check",
 			wantStatus: "PASS",
 		},
+		{
+			name: "Row Remap Error Check Result",
+			addFunc: func(r *Reporter) {
+				r.AddRowRemapResult("PASS", nil, 0)
+			},
+			resultKey:  "row_remap_error_check",
+			wantStatus: "PASS",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/test_limits/test_limits.json
+++ b/internal/test_limits/test_limits.json
@@ -194,6 +194,14 @@
           "valid_max_acc_values": [0, 44, 128],
           "required_advanced_pci_settings": true
         }
+      },
+      "row_remap_error_check": {
+        "enabled": true,
+        "test_category": "LEVEL_1",
+        "threshold": {
+          "minimum-error": 0,
+          "minimum-nvidia-smi-version": 550
+        }
       }
     },
     "BM.GPU.B200.8": {
@@ -277,6 +285,14 @@
       "max_acc_check": {
         "enabled": false,
         "test_category": "LEVEL_1"
+      },
+      "row_remap_error_check": {
+        "enabled": false,
+        "test_category": "LEVEL_1",
+        "threshold": {
+          "minimum-error": 0,
+          "minimum-nvidia-smi-version": 550
+        }
       }
     },
     "BM.GPU.GB200.4": {
@@ -374,6 +390,14 @@
       "max_acc_check": {
         "enabled": false,
         "test_category": "LEVEL_1"
+      },
+      "row_remap_error_check": {
+        "enabled": false,
+        "test_category": "LEVEL_1",
+        "threshold": {
+          "minimum-error": 0,
+          "minimum-nvidia-smi-version": 550
+        }
       }
     }
   }

--- a/internal/test_limits/test_limits_test.go
+++ b/internal/test_limits/test_limits_test.go
@@ -284,8 +284,8 @@ func TestGetEnabledTests(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get enabled tests: %v", err)
 	}
-	if len(enabledTests) != 21 {
-		t.Errorf("Expected 21 enabled tests for H100, got %d", len(enabledTests))
+	if len(enabledTests) != 22 {
+		t.Errorf("Expected 22 enabled tests for H100, got %d", len(enabledTests))
 	}
 
 	expectedTests := map[string]bool{
@@ -310,6 +310,7 @@ func TestGetEnabledTests(t *testing.T) {
 		"missing_interface_check": false,
 		"gpu_xid_check":           false,
 		"max_acc_check":           false,
+		"row_remap_error_check":   false,
 	}
 
 	for _, test := range enabledTests {

--- a/scripts/BM.GPU.H100.8/row_remap_error_check.py
+++ b/scripts/BM.GPU.H100.8/row_remap_error_check.py
@@ -1,0 +1,136 @@
+"""
+Script to check for GPU row remap errors on NVIDIA GPUs.
+This script runs the command `nvidia-smi --query-remapped-rows=gpu_bus_id,remapped_rows.failure --format=csv,noheader`
+to gather row remap failure information, and parses the output to determine if any GPUs
+have row remap failures. Row remap failures indicate memory errors in the GPU.
+"""
+import shlex
+import subprocess
+import json
+
+
+# Function to run command and capture output
+def run_cmd(cmd):
+    cmd_split = shlex.split(cmd)
+    try:
+        results = subprocess.run(cmd_split, shell=False, stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT, check=True, encoding='utf8')
+        output = results.stdout.splitlines()
+    except subprocess.CalledProcessError as e_process_error:
+        return [f"Error: {cmd} {e_process_error.returncode} {e_process_error.output}"]
+    return output
+
+
+def parse_row_remap_results(results="undefined"):
+    result = {
+        "row_remap_error":
+            {"status": "PASS"}
+    }
+    
+    # Expected GPU bus IDs for H100 shape
+    expected_bus_ids = {
+        "00000000:0F:00.0",
+        "00000000:2D:00.0", 
+        "00000000:44:00.0",
+        "00000000:5B:00.0",
+        "00000000:89:00.0",
+        "00000000:A8:00.0",
+        "00000000:C0:00.0",
+        "00000000:D8:00.0"
+    }
+    
+    if len(results) == 0:
+        result["row_remap_error"]["status"] = "FAIL"
+        result["row_remap_error"]["error"] = "No nvidia-smi output received"
+        return result
+    
+    found_bus_ids = set()
+    failed_bus_ids = []
+    
+    for line in results:
+        line = line.strip()
+        if not line or line.startswith("Error:"):
+            continue
+            
+        # Parse CSV format: gpu_bus_id, remapped_rows.failure
+        parts = line.split(',')
+        if len(parts) >= 2:
+            bus_id = parts[0].strip()
+            failure_count = parts[1].strip()
+            
+            found_bus_ids.add(bus_id)
+            
+            # Check if failure count is not 0
+            try:
+                if int(failure_count) != 0:
+                    failed_bus_ids.append(bus_id)
+            except ValueError:
+                # If we can't parse the failure count, treat as failure
+                failed_bus_ids.append(bus_id)
+    
+    # Check if all expected bus IDs are present
+    missing_bus_ids = expected_bus_ids - found_bus_ids
+    if missing_bus_ids:
+        result["row_remap_error"]["status"] = "FAIL"
+        result["row_remap_error"]["missing_gpus"] = list(missing_bus_ids)
+    
+    # Check if any GPUs have row remap failures
+    if failed_bus_ids:
+        result["row_remap_error"]["status"] = "FAIL"
+        result["row_remap_error"]["failed_gpus"] = failed_bus_ids
+    
+    return result
+
+
+def get_nvidia_driver_version():
+    """ Get nvidia-smi driver version """
+    cmd = "nvidia-smi --query-gpu=driver_version --format=csv,noheader,nounits"
+    raw_result = run_cmd(cmd)
+    
+    if len(raw_result) == 0 or raw_result[0].startswith("Error:"):
+        return None
+    
+    # Get the first line and extract version
+    version_line = raw_result[0].strip()
+    # Extract numeric part (e.g., "550.54.15" -> 550)
+    import re
+    version_match = re.search(r'(\d+)', version_line)
+    if version_match:
+        return int(version_match.group(1))
+    return None
+
+
+def run_row_remap_error_check():
+    """ Check for GPU row remap errors """
+    # Check nvidia-smi driver version first
+    driver_version = get_nvidia_driver_version()
+    if driver_version is None:
+        return {
+            "row_remap_error": {
+                "status": "FAIL",
+                "error": "could not determine nvidia-smi driver version"
+            }
+        }
+    
+    if driver_version < 550:
+        return {
+            "row_remap_error": {
+                "status": f"Not applicable for nvidia-smi driver : {driver_version}"
+            }
+        }
+    
+    cmd = "nvidia-smi --query-remapped-rows=gpu_bus_id,remapped_rows.failure --format=csv,noheader"
+    raw_result = run_cmd(cmd)
+    result = parse_row_remap_results(raw_result)
+    return result
+
+
+def main():
+    print("Health check is in progress and the result will be provided within 1 minute.")
+    result = run_row_remap_error_check()
+    print(json.dumps(result, indent=2))
+
+
+# Run the main function
+if __name__ == "__main__":
+    main()

--- a/scripts/BM.GPU.H100.8/row_remap_error_check.sh
+++ b/scripts/BM.GPU.H100.8/row_remap_error_check.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Row Remap Error Check Script
+# This script checks for GPU row remap errors by querying remapped rows failure count
+# Row remap failures indicate memory errors in the GPU
+
+echo "Starting row remap error health check..."
+echo "This will take about 1 minute to complete."
+
+# Check nvidia-smi driver version first
+driver_version=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader,nounits 2>/dev/null | head -1 | grep -o '^[0-9]*')
+
+if [ -z "$driver_version" ]; then
+    echo "Error: Could not determine nvidia-smi driver version"
+    jq -n '{"row_remap_error": {"status": "FAIL", "error": "could not determine nvidia-smi driver version"}}'
+    exit 1
+fi
+
+if [ "$driver_version" -lt 550 ]; then
+    echo "Driver version $driver_version is below required version 550"
+    jq -n --arg version "$driver_version" '{"row_remap_error": {"status": ("Not applicable for nvidia-smi driver : " + $version)}}'
+    exit 0
+fi
+
+# Expected GPU bus IDs for H100 shape
+expected_bus_ids=(
+    "00000000:0F:00.0"
+    "00000000:2D:00.0"
+    "00000000:44:00.0"
+    "00000000:5B:00.0"
+    "00000000:89:00.0"
+    "00000000:A8:00.0"
+    "00000000:C0:00.0"
+    "00000000:D8:00.0"
+)
+
+# Run nvidia-smi command to get row remap information
+echo "Checking for GPU row remap errors..."
+output=$(nvidia-smi --query-remapped-rows=gpu_bus_id,remapped_rows.failure --format=csv,noheader 2>&1)
+
+# Check if command failed
+if [ $? -ne 0 ]; then
+    echo "Error: Could not run nvidia-smi command"
+    jq -n '{"row_remap_error": {"status": "FAIL", "error": "nvidia-smi command failed"}}'
+    exit 1
+fi
+
+# Check if output is empty
+if [ -z "$output" ]; then
+    echo "Error: No nvidia-smi output received"
+    jq -n '{"row_remap_error": {"status": "FAIL", "error": "No nvidia-smi output received"}}'
+    exit 1
+fi
+
+# Arrays to track results
+declare -A found_bus_ids
+failed_bus_ids=()
+missing_bus_ids=()
+
+# Parse the CSV output
+while IFS= read -r line; do
+    line=$(echo "$line" | xargs)  # Trim whitespace
+    
+    # Skip empty lines or error lines
+    if [[ -z "$line" || "$line" == Error:* ]]; then
+        continue
+    fi
+    
+    # Parse CSV format: gpu_bus_id, remapped_rows.failure
+    IFS=',' read -r bus_id failure_count <<< "$line"
+    bus_id=$(echo "$bus_id" | xargs)  # Trim whitespace
+    failure_count=$(echo "$failure_count" | xargs)  # Trim whitespace
+    
+    # Mark this bus ID as found
+    found_bus_ids["$bus_id"]=1
+    
+    # Check if failure count is not 0
+    if [[ "$failure_count" != "0" ]]; then
+        failed_bus_ids+=("$bus_id")
+        echo "Found row remap failure on GPU: $bus_id (failures: $failure_count)"
+    fi
+done <<< "$output"
+
+# Check for missing GPUs
+for expected_id in "${expected_bus_ids[@]}"; do
+    if [[ -z "${found_bus_ids[$expected_id]}" ]]; then
+        missing_bus_ids+=("$expected_id")
+        echo "Missing expected GPU: $expected_id"
+    fi
+done
+
+# Determine overall status
+status="PASS"
+result_json='{"row_remap_error": {"status": "PASS"}}'
+
+# Check for failures
+if [[ ${#failed_bus_ids[@]} -gt 0 || ${#missing_bus_ids[@]} -gt 0 ]]; then
+    status="FAIL"
+    
+    # Build JSON result with failure details
+    if [[ ${#failed_bus_ids[@]} -gt 0 && ${#missing_bus_ids[@]} -gt 0 ]]; then
+        # Both failed and missing GPUs
+        failed_list=$(printf '%s\n' "${failed_bus_ids[@]}" | jq -R . | jq -s .)
+        missing_list=$(printf '%s\n' "${missing_bus_ids[@]}" | jq -R . | jq -s .)
+        result_json=$(jq -n \
+            --argjson failed "$failed_list" \
+            --argjson missing "$missing_list" \
+            '{"row_remap_error": {"status": "FAIL", "failed_gpus": $failed, "missing_gpus": $missing}}')
+    elif [[ ${#failed_bus_ids[@]} -gt 0 ]]; then
+        # Only failed GPUs
+        failed_list=$(printf '%s\n' "${failed_bus_ids[@]}" | jq -R . | jq -s .)
+        result_json=$(jq -n \
+            --argjson failed "$failed_list" \
+            '{"row_remap_error": {"status": "FAIL", "failed_gpus": $failed}}')
+    else
+        # Only missing GPUs
+        missing_list=$(printf '%s\n' "${missing_bus_ids[@]}" | jq -R . | jq -s .)
+        result_json=$(jq -n \
+            --argjson missing "$missing_list" \
+            '{"row_remap_error": {"status": "FAIL", "missing_gpus": $missing}}')
+    fi
+else
+    echo "No row remap errors found"
+fi
+
+# Print the final result
+echo "$result_json"


### PR DESCRIPTION

⏺ Add row remap error check functionality

  ## Summary
  Implements comprehensive GPU row remap error detection across Python, shell, and Go
  implementations with driver version validation and integration into the diagnostic framework.

  ## Changes
  - Added `row_remap_error_check.py` and `row_remap_error_check.sh` scripts with nvidia-smi driver
   version checks (>= 550)
  - Implemented `row_remap_error_check.go` with case-insensitive bus ID matching and shapes
  integration
  - Updated `test_limits.json` with nested threshold configuration for row remap checks
  - Added comprehensive recommendations in `recommendations.json` with fault code HPCGPU-0013-0001
  - Integrated into reporter system with support for JSON, table, and friendly output formats
  - Added unit tests for core parsing functionality
  - Updated recommender system with `{failure_count}` variable substitution support

  ## Test plan
  - [x] Run row remap error check on H100 systems with nvidia-smi >= 550
  - [x] Verify driver version validation works correctly for older drivers
  - [x] Test case-insensitive bus ID matching
  - [x] Validate recommendation generation with proper fault codes
  - [x] Ensure all output formats display row remap results correctly