### PR TITLE
Add PCIe width missing lanes check

### DIFF
--- a/cmd/level1.go
+++ b/cmd/level1.go
@@ -67,6 +67,7 @@ func runAllLevel1Tests() error {
 	}{
 		{"gpu_count_check", level1_tests.RunGPUCountCheck},
 		{"pcie_error_check", level1_tests.RunPCIeErrorCheck},
+		{"pcie_width_missing_lanes_check", level1_tests.RunPCIeWidthMissingLanesCheck},
 		{"rdma_nics_count", level1_tests.RunRDMANicsCount},
 		{"rx_discards_check", level1_tests.RunRXDiscardsCheck},
 		{"gid_index_check", level1_tests.RunGIDIndexCheck},
@@ -144,6 +145,7 @@ func runSpecificTests(testFilter string) error {
 	}{
 		{"gpu_count_check", "Check GPU count using nvidia-smi", level1_tests.RunGPUCountCheck},
 		{"pcie_error_check", "Check for PCIe errors in system logs", level1_tests.RunPCIeErrorCheck},
+		{"pcie_width_missing_lanes_check", "Check PCIe link width for missing lanes", level1_tests.RunPCIeWidthMissingLanesCheck},
 		{"rdma_nics_count", "Check RDMA NICs count", level1_tests.RunRDMANicsCount},
 		{"rx_discards_check", "Check Network Interface for rx discard", level1_tests.RunRXDiscardsCheck},
 		{"gid_index_check", "Check device GID Index are in range ", level1_tests.RunGIDIndexCheck},

--- a/configs/recommendations.json
+++ b/configs/recommendations.json
@@ -110,6 +110,34 @@
         ]
       }
     },
+    "pcie_width_missing_lanes_check": {
+      "fail": {
+        "type": "critical",
+        "fault_code": "HPCGPU-0010-0001",
+        "issue": "PCIe link width, speed, or state mismatch detected - some lanes are missing or interfaces are not operating correctly",
+        "suggestion": "Please reboot the host and if the issue persists, send the node to OCI",
+        "commands": [
+          "sudo lspci -vvv | egrep '^[0-9,a-f]|LnkSta:' | grep -A 1 -i nvidia | grep LnkSta | sort | uniq -c",
+          "sudo lspci -vvv | egrep '^[0-9,a-f]|LnkSta:' | grep -A 1 -i mellanox | grep LnkSta | sort | uniq -c",
+          "lspci -tv",
+          "dmesg | grep -i pcie",
+          "sudo lspci -vvv | grep -E 'LnkSta|Speed|Width'"
+        ],
+        "references": [
+          "https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm",
+          "https://www.kernel.org/doc/Documentation/PCI/pci.txt"
+        ]
+      },
+      "pass": {
+        "type": "info",
+        "issue": "PCIe width, speed, and state check passed",
+        "suggestion": "All PCIe interfaces are operating at expected width, speed, and healthy state",
+        "commands": [
+          "lspci -tv",
+          "sudo lspci -vvv | grep LnkSta"
+        ]
+      }
+    },
     "rdma_nics_count": {
       "fail": {
         "type": "warning",

--- a/internal/executor/os_commands.go
+++ b/internal/executor/os_commands.go
@@ -638,3 +638,4 @@ func RunWpaCliStatus(interfaceName string) (*OSCommandResult, error) {
 
 	return result, nil
 }
+

--- a/internal/level1_tests/pcie_width_missing_lanes_check.go
+++ b/internal/level1_tests/pcie_width_missing_lanes_check.go
@@ -1,0 +1,489 @@
+package level1_tests
+
+import (
+	"fmt"
+	"github.com/oracle/oci-dr-hpc-v2/internal/test_limits"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/oracle/oci-dr-hpc-v2/internal/executor"
+	"github.com/oracle/oci-dr-hpc-v2/internal/logger"
+	"github.com/oracle/oci-dr-hpc-v2/internal/reporter"
+)
+
+// PCIeWidthResult represents PCIe width analysis results
+type PCIeWidthResult struct {
+	WidthCounts map[string]int `json:"width_counts"`
+	SpeedCounts map[string]int `json:"speed_counts"`
+	StateErrors []string       `json:"state_errors"`
+	Success     bool           `json:"success"`
+	ErrorMsg    string         `json:"error_message,omitempty"`
+}
+
+// PCIeWidthMissingLanesTestConfig holds configuration for this test
+type PCIeWidthMissingLanesTestConfig struct {
+	IsEnabled            bool               `json:"enabled"`
+	ExpectedGPUWidths    map[string]int     `json:"expected_gpu_widths"`
+	ExpectedRDMAWidths   map[string]int     `json:"expected_rdma_widths"`
+	ExpectedGPUSpeeds    map[string]int     `json:"expected_gpu_speeds"`
+	ExpectedRDMASpeeds   map[string]int     `json:"expected_rdma_speeds"`
+	ExpectedLinkState    string             `json:"expected_link_state"`
+}
+
+// getpcieWidthMissingLanesTestConfig loads test configuration
+func getPcieWidthMissingLanesTestConfig(shape string) (*PCIeWidthMissingLanesTestConfig, error) {
+	// Load configuration from test_limits.json
+	limits, err := test_limits.LoadTestLimits()
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize config with defaults
+	config := &PCIeWidthMissingLanesTestConfig{
+		IsEnabled:           false,
+		ExpectedGPUWidths:   make(map[string]int),
+		ExpectedRDMAWidths:  make(map[string]int),
+		ExpectedGPUSpeeds:   make(map[string]int),
+		ExpectedRDMASpeeds:  make(map[string]int),
+		ExpectedLinkState:   "Ok",
+	}
+
+	// Check if test is enabled
+	enabled, err := limits.IsTestEnabled(shape, "pcie_width_missing_lanes_check")
+	if err != nil {
+		return nil, err
+	}
+	config.IsEnabled = enabled
+
+	// Get expected GPU widths
+	gpuWidthsData, err := limits.GetThresholdForTest(shape, "pcie_width_missing_lanes_check")
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the threshold data
+	if thresholdMap, ok := gpuWidthsData.(map[string]interface{}); ok {
+		// Parse GPU widths
+		if gpuWidths, exists := thresholdMap["gpu_widths"]; exists {
+			if gpuMap, ok := gpuWidths.(map[string]interface{}); ok {
+				for width, count := range gpuMap {
+					if countFloat, ok := count.(float64); ok {
+						config.ExpectedGPUWidths[width] = int(countFloat)
+					}
+				}
+			}
+		}
+
+		// Parse RDMA widths
+		if rdmaWidths, exists := thresholdMap["rdma_widths"]; exists {
+			if rdmaMap, ok := rdmaWidths.(map[string]interface{}); ok {
+				for width, count := range rdmaMap {
+					if countFloat, ok := count.(float64); ok {
+						config.ExpectedRDMAWidths[width] = int(countFloat)
+					}
+				}
+			}
+		}
+
+		// Parse GPU speeds
+		if gpuSpeeds, exists := thresholdMap["gpu_speeds"]; exists {
+			if gpuSpeedMap, ok := gpuSpeeds.(map[string]interface{}); ok {
+				for speed, count := range gpuSpeedMap {
+					if countFloat, ok := count.(float64); ok {
+						config.ExpectedGPUSpeeds[speed] = int(countFloat)
+					}
+				}
+			}
+		}
+
+		// Parse RDMA speeds
+		if rdmaSpeeds, exists := thresholdMap["rdma_speeds"]; exists {
+			if rdmaSpeedMap, ok := rdmaSpeeds.(map[string]interface{}); ok {
+				for speed, count := range rdmaSpeedMap {
+					if countFloat, ok := count.(float64); ok {
+						config.ExpectedRDMASpeeds[speed] = int(countFloat)
+					}
+				}
+			}
+		}
+
+		// Parse expected link state
+		if linkState, exists := thresholdMap["expected_link_state"]; exists {
+			if stateStr, ok := linkState.(string); ok {
+				config.ExpectedLinkState = stateStr
+			}
+		}
+	}
+
+	return config, nil
+}
+
+// PCIeParseResult holds parsed PCIe information
+type PCIeParseResult struct {
+	WidthCounts map[string]int
+	SpeedCounts map[string]int
+	StateErrors []string
+}
+
+// FilterLspciForDevice filters lspci output to extract LnkSta lines for specific device type
+func FilterLspciForDevice(lspciOutput string, deviceType string) string {
+	lines := strings.Split(lspciOutput, "\n")
+	var filteredLines []string
+	var deviceFound bool
+	
+	devicePattern := strings.ToLower(deviceType)
+	
+	for _, line := range lines {
+		// Check if this line is a PCI device header (starts with bus:device.function)
+		if regexp.MustCompile(`^[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9a-fA-F]`).MatchString(line) {
+			// Reset device found flag
+			deviceFound = false
+			
+			// Check if this device matches our target type
+			lowerLine := strings.ToLower(line)
+			switch devicePattern {
+			case "nvidia", "gpu", "nvswitch":
+				deviceFound = strings.Contains(lowerLine, "nvidia")
+			case "mellanox", "rdma":
+				deviceFound = strings.Contains(lowerLine, "mellanox")
+			}
+		}
+		
+		// If we found a matching device and this line contains LnkSta, include it
+		if deviceFound && strings.Contains(line, "LnkSta:") {
+			filteredLines = append(filteredLines, line)
+		}
+	}
+	
+	return strings.Join(filteredLines, "\n")
+}
+
+// AggregateLinkStatistics aggregates LnkSta lines by counting identical entries
+func AggregateLinkStatistics(linkStatusLines string) string {
+	if strings.TrimSpace(linkStatusLines) == "" {
+		return ""
+	}
+	
+	lines := strings.Split(strings.TrimSpace(linkStatusLines), "\n")
+	countMap := make(map[string]int)
+	
+	// Count occurrences of each unique LnkSta line
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			countMap[line]++
+		}
+	}
+	
+	// Convert back to the format expected by parseLspciWidthOutput
+	var result []string
+	for line, count := range countMap {
+		result = append(result, fmt.Sprintf("%d\t%s", count, line))
+	}
+	
+	return strings.Join(result, "\n")
+}
+
+// parseLspciWidthOutput parses lspci output to extract PCIe width, speed, and state information
+func parseLspciWidthOutput(output string, expectedLinkState string) PCIeParseResult {
+	result := PCIeParseResult{
+		WidthCounts: make(map[string]int),
+		SpeedCounts: make(map[string]int),
+		StateErrors: []string{},
+	}
+	
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	
+	// Enhanced regex to capture count, speed with (ok), width with (ok)
+	// Example: "4       LnkSta: Speed 16GT/s (ok), Width x16 (ok)"
+	re := regexp.MustCompile(`^\s*(\d+)\s+LnkSta:\s*Speed\s+([^\s]+)\s*\(([^)]+)\),\s*Width\s+x(\d+)\s*\(([^)]+)\)`)
+	
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		
+		matches := re.FindStringSubmatch(line)
+		if len(matches) == 6 {
+			count, err := strconv.Atoi(matches[1])
+			if err != nil {
+				logger.Debugf("Failed to parse count from line: %s", line)
+				continue
+			}
+			
+			speed := strings.TrimSpace(matches[2])
+			speedState := strings.TrimSpace(matches[3])
+			width := matches[4]
+			widthState := strings.TrimSpace(matches[5])
+			
+			// Count widths only if width state is ok
+			widthKey := fmt.Sprintf("Width x%s", width)
+			if widthState == "ok" {
+				result.WidthCounts[widthKey] += count
+			} else {
+				result.StateErrors = append(result.StateErrors, 
+					fmt.Sprintf("%d devices have width state '%s' instead of 'ok'", count, widthState))
+			}
+			
+			// Count speeds only if speed state is ok
+			speedKey := fmt.Sprintf("Speed %s", speed)
+			if speedState == "ok" {
+				result.SpeedCounts[speedKey] += count
+			} else {
+				result.StateErrors = append(result.StateErrors, 
+					fmt.Sprintf("%d devices have speed state '%s' instead of 'ok'", count, speedState))
+			}
+			
+			logger.Debugf("Parsed PCIe: %s (%s) = %d, %s (%s) = %d", widthKey, widthState, count, speedKey, speedState, count)
+		}
+	}
+	
+	return result
+}
+
+// checkGPUNVSwitchPCIeWidth checks PCIe width, speed, and state for GPU and NVSwitch interfaces
+func checkGPUNVSwitchPCIeWidth(expectedLinkState string) PCIeWidthResult {
+	logger.Info("Checking GPU/NVSwitch PCIe width, speed, and state...")
+	
+	// Execute the lspci command with verbose output
+	result, err := executor.RunLspci("-vvv")
+	if err != nil {
+		return PCIeWidthResult{
+			Success:  false,
+			ErrorMsg: fmt.Sprintf("Failed to execute lspci command: %v", err),
+		}
+	}
+	
+	if result.ExitCode != 0 {
+		return PCIeWidthResult{
+			Success:  false,
+			ErrorMsg: fmt.Sprintf("lspci command failed with exit code %d: %s", result.ExitCode, result.Output),
+		}
+	}
+	
+	// Filter lspci output for NVIDIA devices and extract LnkSta lines
+	filteredOutput := FilterLspciForDevice(result.Output, "nvidia")
+	if strings.TrimSpace(filteredOutput) == "" {
+		return PCIeWidthResult{
+			Success:  false,
+			ErrorMsg: "No NVIDIA PCIe devices found",
+		}
+	}
+	
+	// Aggregate identical LnkSta lines with counts
+	aggregatedOutput := AggregateLinkStatistics(filteredOutput)
+	
+	parseResult := parseLspciWidthOutput(aggregatedOutput, expectedLinkState)
+	
+	return PCIeWidthResult{
+		WidthCounts: parseResult.WidthCounts,
+		SpeedCounts: parseResult.SpeedCounts,
+		StateErrors: parseResult.StateErrors,
+		Success:     true,
+	}
+}
+
+// checkRDMAPCIeWidth checks PCIe width, speed, and state for RDMA interfaces
+func checkRDMAPCIeWidth(expectedLinkState string) PCIeWidthResult {
+	logger.Info("Checking RDMA PCIe width, speed, and state...")
+	
+	// Execute the lspci command with verbose output
+	result, err := executor.RunLspci("-vvv")
+	if err != nil {
+		return PCIeWidthResult{
+			Success:  false,
+			ErrorMsg: fmt.Sprintf("Failed to execute lspci command: %v", err),
+		}
+	}
+	
+	if result.ExitCode != 0 {
+		return PCIeWidthResult{
+			Success:  false,
+			ErrorMsg: fmt.Sprintf("lspci command failed with exit code %d: %s", result.ExitCode, result.Output),
+		}
+	}
+	
+	// Filter lspci output for Mellanox devices and extract LnkSta lines
+	filteredOutput := FilterLspciForDevice(result.Output, "mellanox")
+	if strings.TrimSpace(filteredOutput) == "" {
+		return PCIeWidthResult{
+			Success:  false,
+			ErrorMsg: "No Mellanox PCIe devices found",
+		}
+	}
+	
+	// Aggregate identical LnkSta lines with counts
+	aggregatedOutput := AggregateLinkStatistics(filteredOutput)
+	
+	parseResult := parseLspciWidthOutput(aggregatedOutput, expectedLinkState)
+	
+	return PCIeWidthResult{
+		WidthCounts: parseResult.WidthCounts,
+		SpeedCounts: parseResult.SpeedCounts,
+		StateErrors: parseResult.StateErrors,
+		Success:     true,
+	}
+}
+
+// validateWidthCounts compares actual vs expected width counts
+func validateWidthCounts(actual, expected map[string]int, deviceType string) (bool, string) {
+	for width, expectedCount := range expected {
+		actualCount, exists := actual[width]
+		if !exists {
+			actualCount = 0
+		}
+		
+		if actualCount != expectedCount {
+			return false, fmt.Sprintf("%s PCIe width mismatch: expected %dx %s, got %dx %s", 
+				deviceType, expectedCount, width, actualCount, width)
+		}
+	}
+	
+	return true, ""
+}
+
+// validateSpeedCounts compares actual vs expected speed counts
+func validateSpeedCounts(actual, expected map[string]int, deviceType string) (bool, string) {
+	for speed, expectedCount := range expected {
+		actualCount, exists := actual[speed]
+		if !exists {
+			actualCount = 0
+		}
+		
+		if actualCount != expectedCount {
+			return false, fmt.Sprintf("%s PCIe speed mismatch: expected %dx %s, got %dx %s", 
+				deviceType, expectedCount, speed, actualCount, speed)
+		}
+	}
+	
+	return true, ""
+}
+
+// RunPCIeWidthMissingLanesCheck performs the PCIe width missing lanes diagnostic
+func RunPCIeWidthMissingLanesCheck() error {
+	logger.Info("=== PCIe Width Missing Lanes Check ===")
+	rep := reporter.GetReporter()
+
+	// Step 1: Get shape from IMDS
+	logger.Info("Step 1: Getting shape from IMDS...")
+	shape, err := executor.GetCurrentShape()
+	if err != nil {
+		logger.Error("PCIe Width Missing Lanes Check: FAIL - Could not get shape from IMDS:", err)
+		rep.AddPCIeWidthResult("FAIL", nil, nil, nil, nil, nil, err)
+		return fmt.Errorf("failed to get shape from IMDS: %w", err)
+	}
+	logger.Info("Current shape from IMDS:", shape)
+
+	// Step 2: Load test configuration
+	config, err := getPcieWidthMissingLanesTestConfig(shape)
+	if err != nil {
+		logger.Error("PCIe Width Missing Lanes Check: FAIL - Could not load test configuration:", err)
+		rep.AddPCIeWidthResult("FAIL", nil, nil, nil, nil, nil, err)
+		return fmt.Errorf("failed to load test configuration: %w", err)
+	}
+
+	if !config.IsEnabled {
+		errorMsg := fmt.Sprintf("Test not applicable for this shape %s", shape)
+		logger.Error(errorMsg)
+		rep.AddPCIeWidthResult("SKIP", nil, nil, nil, nil, nil, fmt.Errorf(errorMsg))
+		return fmt.Errorf(errorMsg)
+	}
+
+	// Step 3: Check GPU/NVSwitch PCIe width, speed, and state
+	logger.Info("Step 2: Checking GPU/NVSwitch PCIe width, speed, and state...")
+	gpuResult := checkGPUNVSwitchPCIeWidth(config.ExpectedLinkState)
+	
+	var errorMessages []string
+	var allGPUWidths map[string]int
+	var allRDMAWidths map[string]int
+	var allGPUSpeeds map[string]int
+	var allRDMASpeeds map[string]int
+	var allStateErrors []string
+
+	if !gpuResult.Success {
+		errorMessages = append(errorMessages, fmt.Sprintf("GPU/NVSwitch: %s", gpuResult.ErrorMsg))
+		allGPUWidths = make(map[string]int)
+		allGPUSpeeds = make(map[string]int)
+	} else {
+		allGPUWidths = gpuResult.WidthCounts
+		allGPUSpeeds = gpuResult.SpeedCounts
+		allStateErrors = append(allStateErrors, gpuResult.StateErrors...)
+		
+		// Validate GPU widths
+		if len(config.ExpectedGPUWidths) > 0 {
+			gpuValid, gpuError := validateWidthCounts(allGPUWidths, config.ExpectedGPUWidths, "GPU/NVSwitch")
+			if !gpuValid {
+				errorMessages = append(errorMessages, gpuError)
+			}
+		}
+		
+		// Validate GPU speeds
+		if len(config.ExpectedGPUSpeeds) > 0 {
+			gpuSpeedValid, gpuSpeedError := validateSpeedCounts(gpuResult.SpeedCounts, config.ExpectedGPUSpeeds, "GPU/NVSwitch")
+			if !gpuSpeedValid {
+				errorMessages = append(errorMessages, gpuSpeedError)
+			}
+		}
+		
+		// Check GPU state errors
+		if len(gpuResult.StateErrors) > 0 {
+			for _, stateError := range gpuResult.StateErrors {
+				errorMessages = append(errorMessages, fmt.Sprintf("GPU/NVSwitch state error: %s", stateError))
+			}
+		}
+	}
+
+	// Step 4: Check RDMA PCIe width, speed, and state
+	logger.Info("Step 3: Checking RDMA PCIe width, speed, and state...")
+	rdmaResult := checkRDMAPCIeWidth(config.ExpectedLinkState)
+	
+	if !rdmaResult.Success {
+		errorMessages = append(errorMessages, fmt.Sprintf("RDMA: %s", rdmaResult.ErrorMsg))
+		allRDMAWidths = make(map[string]int)
+		allRDMASpeeds = make(map[string]int)
+	} else {
+		allRDMAWidths = rdmaResult.WidthCounts
+		allRDMASpeeds = rdmaResult.SpeedCounts
+		allStateErrors = append(allStateErrors, rdmaResult.StateErrors...)
+		
+		// Validate RDMA widths
+		if len(config.ExpectedRDMAWidths) > 0 {
+			rdmaValid, rdmaError := validateWidthCounts(allRDMAWidths, config.ExpectedRDMAWidths, "RDMA")
+			if !rdmaValid {
+				errorMessages = append(errorMessages, rdmaError)
+			}
+		}
+		
+		// Validate RDMA speeds
+		if len(config.ExpectedRDMASpeeds) > 0 {
+			rdmaSpeedValid, rdmaSpeedError := validateSpeedCounts(rdmaResult.SpeedCounts, config.ExpectedRDMASpeeds, "RDMA")
+			if !rdmaSpeedValid {
+				errorMessages = append(errorMessages, rdmaSpeedError)
+			}
+		}
+		
+		// Check RDMA state errors
+		if len(rdmaResult.StateErrors) > 0 {
+			for _, stateError := range rdmaResult.StateErrors {
+				errorMessages = append(errorMessages, fmt.Sprintf("RDMA state error: %s", stateError))
+			}
+		}
+	}
+
+	// Step 5: Generate final result
+	if len(errorMessages) == 0 {
+		logger.Info("PCIe Width Missing Lanes Check: PASS - All PCIe interfaces operating at expected width and speed")
+		rep.AddPCIeWidthResult("PASS", allGPUWidths, allRDMAWidths, allGPUSpeeds, allRDMASpeeds, allStateErrors, nil)
+		return nil
+	} else {
+		// Combine error messages
+		combinedError := strings.Join(errorMessages, "; ") + ". Please reboot the host and if the issue persists, send the node to OCI."
+		logger.Error("PCIe Width Missing Lanes Check: FAIL -", combinedError)
+		
+		err := fmt.Errorf(combinedError)
+		rep.AddPCIeWidthResult("FAIL", allGPUWidths, allRDMAWidths, allGPUSpeeds, allRDMASpeeds, allStateErrors, err)
+		return err
+	}
+}

--- a/internal/level1_tests/pcie_width_missing_lanes_check_test.go
+++ b/internal/level1_tests/pcie_width_missing_lanes_check_test.go
@@ -1,0 +1,641 @@
+package level1_tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Mock lspci output for testing
+const (
+	mockNvidiaLspciOutput = `      4           LnkSta:     Speed 16GT/s (ok), Width x2 (ok)
+      8           LnkSta:     Speed 32GT/s (ok), Width x16 (ok)`
+
+	mockMellanoxLspciOutput = `      2           LnkSta:     Speed 16GT/s (ok), Width x8 (ok)
+     16           LnkSta:     Speed 32GT/s (ok), Width x16 (ok)`
+
+	mockInvalidNvidiaLspciOutput = `      2           LnkSta:     Speed 16GT/s (ok), Width x2 (ok)
+      6           LnkSta:     Speed 32GT/s (ok), Width x16 (ok)`
+
+	mockInvalidMellanoxLspciOutput = `      1           LnkSta:     Speed 16GT/s (ok), Width x8 (ok)
+     15           LnkSta:     Speed 32GT/s (ok), Width x16 (ok)`
+
+	mockEmptyLspciOutput = ``
+
+	mockMixedFormatLspciOutput = `      4           LnkSta:     Speed 16GT/s (ok), Width x2 (ok)
+      8           LnkSta2:    Speed 32GT/s (ok), Width x16 (ok)
+invalid line without width info
+      2           LnkSta:     Speed 16GT/s (ok), Width x8 (ok)`
+
+	mockErrorStateLspciOutput = `      4           LnkSta:     Speed 16GT/s (error), Width x2 (ok)
+      8           LnkSta:     Speed 16GT/s (ok), Width x16 (degraded)`
+
+	mockSpeedVariationsOutput = `      4           LnkSta:     Speed 8GT/s (ok), Width x2 (ok)
+      8           LnkSta:     Speed 16GT/s (ok), Width x16 (ok)`
+)
+
+// createTempTestLimitsFile creates a temporary test_limits.json file for testing
+func createTempTestLimitsFile(t *testing.T, content string) string {
+	tempDir := t.TempDir()
+	limitsFile := filepath.Join(tempDir, "test_limits.json")
+
+	err := os.WriteFile(limitsFile, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create temp test limits file: %v", err)
+	}
+
+	return limitsFile
+}
+
+func TestParseLspciWidthOutput(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		expectedLinkState string
+		expectedWidths    map[string]int
+		expectedSpeeds    map[string]int
+		expectedStateErrs int
+		description       string
+	}{
+		{
+			name:              "Valid NVIDIA output",
+			input:             mockNvidiaLspciOutput,
+			expectedLinkState: "ok",
+			expectedWidths: map[string]int{
+				"Width x2":  4,
+				"Width x16": 8,
+			},
+			expectedSpeeds: map[string]int{
+				"Speed 16GT/s": 4,
+				"Speed 32GT/s": 8,
+			},
+			expectedStateErrs: 0,
+			description:       "Should parse valid NVIDIA lspci output correctly",
+		},
+		{
+			name:              "Valid Mellanox output",
+			input:             mockMellanoxLspciOutput,
+			expectedLinkState: "ok",
+			expectedWidths: map[string]int{
+				"Width x8":  2,
+				"Width x16": 16,
+			},
+			expectedSpeeds: map[string]int{
+				"Speed 16GT/s": 2,
+				"Speed 32GT/s": 16,
+			},
+			expectedStateErrs: 0,
+			description:       "Should parse valid Mellanox lspci output correctly",
+		},
+		{
+			name:              "Empty output",
+			input:             mockEmptyLspciOutput,
+			expectedLinkState: "ok",
+			expectedWidths:    map[string]int{},
+			expectedSpeeds:    map[string]int{},
+			expectedStateErrs: 0,
+			description:       "Should handle empty output gracefully",
+		},
+		{
+			name:              "Error state output",
+			input:             mockErrorStateLspciOutput,
+			expectedLinkState: "ok",
+			expectedWidths: map[string]int{
+				"Width x2": 4, // Only ok width states count
+			},
+			expectedSpeeds: map[string]int{
+				"Speed 16GT/s": 8, // Only ok speed states count
+			},
+			expectedStateErrs: 2, // Speed error and width error
+			description:       "Should detect state errors and exclude bad states from counts",
+		},
+		{
+			name:              "Mixed format output",
+			input:             mockMixedFormatLspciOutput,
+			expectedLinkState: "ok",
+			expectedWidths: map[string]int{
+				"Width x2": 4,
+				"Width x8": 2,
+			},
+			expectedSpeeds: map[string]int{
+				"Speed 16GT/s": 6,
+			},
+			expectedStateErrs: 0,
+			description:       "Should handle mixed format output and ignore invalid lines",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseLspciWidthOutput(tt.input, tt.expectedLinkState)
+
+			// Check width counts
+			if len(result.WidthCounts) != len(tt.expectedWidths) {
+				t.Errorf("%s: expected %d width entries, got %d", 
+					tt.description, len(tt.expectedWidths), len(result.WidthCounts))
+			}
+
+			for width, expectedCount := range tt.expectedWidths {
+				if actualCount, exists := result.WidthCounts[width]; !exists {
+					if expectedCount != 0 {
+						t.Errorf("%s: expected width %s not found in result", tt.description, width)
+					}
+				} else if actualCount != expectedCount {
+					t.Errorf("%s: width %s expected count %d, got %d", 
+						tt.description, width, expectedCount, actualCount)
+				}
+			}
+
+			// Check speed counts
+			for speed, expectedCount := range tt.expectedSpeeds {
+				if actualCount, exists := result.SpeedCounts[speed]; !exists {
+					t.Errorf("%s: expected speed %s not found in result", tt.description, speed)
+				} else if actualCount != expectedCount {
+					t.Errorf("%s: speed %s expected count %d, got %d", 
+						tt.description, speed, expectedCount, actualCount)
+				}
+			}
+
+			// Check state errors
+			if len(result.StateErrors) != tt.expectedStateErrs {
+				t.Errorf("%s: expected %d state errors, got %d", 
+					tt.description, tt.expectedStateErrs, len(result.StateErrors))
+			}
+		})
+	}
+}
+
+func TestValidateWidthCounts(t *testing.T) {
+	tests := []struct {
+		name         string
+		actual       map[string]int
+		expected     map[string]int
+		deviceType   string
+		shouldPass   bool
+		expectedMsg  string
+		description  string
+	}{
+		{
+			name: "Valid GPU widths",
+			actual: map[string]int{
+				"Width x2":  4,
+				"Width x16": 8,
+			},
+			expected: map[string]int{
+				"Width x2":  4,
+				"Width x16": 8,
+			},
+			deviceType:  "GPU/NVSwitch",
+			shouldPass:  true,
+			description: "Should pass with matching GPU width counts",
+		},
+		{
+			name: "Invalid GPU width count",
+			actual: map[string]int{
+				"Width x2":  2,
+				"Width x16": 6,
+			},
+			expected: map[string]int{
+				"Width x2":  4,
+				"Width x16": 8,
+			},
+			deviceType:   "GPU/NVSwitch",
+			shouldPass:   false,
+			expectedMsg:  "GPU/NVSwitch PCIe width mismatch:",
+			description:  "Should fail with mismatched GPU width counts",
+		},
+		{
+			name: "Missing width entry",
+			actual: map[string]int{
+				"Width x16": 8,
+			},
+			expected: map[string]int{
+				"Width x2":  4,
+				"Width x16": 8,
+			},
+			deviceType:   "GPU/NVSwitch",
+			shouldPass:   false,
+			expectedMsg:  "GPU/NVSwitch PCIe width mismatch: expected 4x Width x2, got 0x Width x2",
+			description:  "Should fail when expected width entry is missing",
+		},
+		{
+			name: "Valid RDMA widths",
+			actual: map[string]int{
+				"Width x8":  2,
+				"Width x16": 16,
+			},
+			expected: map[string]int{
+				"Width x8":  2,
+				"Width x16": 16,
+			},
+			deviceType:  "RDMA",
+			shouldPass:  true,
+			description: "Should pass with matching RDMA width counts",
+		},
+		{
+			name:         "Empty expected counts",
+			actual:       map[string]int{"Width x16": 8},
+			expected:     map[string]int{},
+			deviceType:   "GPU/NVSwitch",
+			shouldPass:   true,
+			description:  "Should pass when no expected counts are specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			success, errorMsg := validateWidthCounts(tt.actual, tt.expected, tt.deviceType)
+
+			if success != tt.shouldPass {
+				t.Errorf("%s: expected success=%v, got success=%v", tt.description, tt.shouldPass, success)
+			}
+
+			if !tt.shouldPass && !strings.Contains(errorMsg, tt.expectedMsg) {
+				t.Errorf("%s: expected error message to contain '%s', got '%s'", 
+					tt.description, tt.expectedMsg, errorMsg)
+			}
+
+			if tt.shouldPass && errorMsg != "" {
+				t.Errorf("%s: expected no error message for passing test, got '%s'", 
+					tt.description, errorMsg)
+			}
+		})
+	}
+}
+
+func TestPCIeWidthResult(t *testing.T) {
+	tests := []struct {
+		name         string
+		widthCounts  map[string]int
+		success      bool
+		errorMsg     string
+		description  string
+	}{
+		{
+			name: "Successful result",
+			widthCounts: map[string]int{
+				"Width x2":  4,
+				"Width x16": 8,
+			},
+			success:     true,
+			errorMsg:    "",
+			description: "Should create successful PCIeWidthResult",
+		},
+		{
+			name:        "Failed result",
+			widthCounts: nil,
+			success:     false,
+			errorMsg:    "Test error message",
+			description: "Should create failed PCIeWidthResult",
+		},
+		{
+			name:        "Empty width counts",
+			widthCounts: map[string]int{},
+			success:     true,
+			errorMsg:    "",
+			description: "Should handle empty width counts",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := PCIeWidthResult{
+				WidthCounts: tt.widthCounts,
+				Success:     tt.success,
+				ErrorMsg:    tt.errorMsg,
+			}
+
+			if result.Success != tt.success {
+				t.Errorf("%s: expected Success=%v, got Success=%v", 
+					tt.description, tt.success, result.Success)
+			}
+
+			if result.ErrorMsg != tt.errorMsg {
+				t.Errorf("%s: expected ErrorMsg='%s', got ErrorMsg='%s'", 
+					tt.description, tt.errorMsg, result.ErrorMsg)
+			}
+
+			if tt.widthCounts == nil && result.WidthCounts != nil {
+				t.Errorf("%s: expected nil WidthCounts, got non-nil", tt.description)
+			}
+
+			if tt.widthCounts != nil {
+				if len(result.WidthCounts) != len(tt.widthCounts) {
+					t.Errorf("%s: expected %d width entries, got %d", 
+						tt.description, len(tt.widthCounts), len(result.WidthCounts))
+				}
+
+				for width, expectedCount := range tt.widthCounts {
+					if actualCount, exists := result.WidthCounts[width]; !exists {
+						t.Errorf("%s: expected width %s not found", tt.description, width)
+					} else if actualCount != expectedCount {
+						t.Errorf("%s: width %s expected count %d, got %d", 
+							tt.description, width, expectedCount, actualCount)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestPCIeWidthMissingLanesTestConfig(t *testing.T) {
+	config := &PCIeWidthMissingLanesTestConfig{
+		IsEnabled: true,
+		ExpectedGPUWidths: map[string]int{
+			"Width x2":  4,
+			"Width x16": 8,
+		},
+		ExpectedRDMAWidths: map[string]int{
+			"Width x8":  2,
+			"Width x16": 16,
+		},
+	}
+
+	if !config.IsEnabled {
+		t.Error("Expected IsEnabled to be true")
+	}
+
+	expectedGPUWidths := map[string]int{
+		"Width x2":  4,
+		"Width x16": 8,
+	}
+
+	if len(config.ExpectedGPUWidths) != len(expectedGPUWidths) {
+		t.Errorf("Expected %d GPU width entries, got %d", 
+			len(expectedGPUWidths), len(config.ExpectedGPUWidths))
+	}
+
+	for width, expectedCount := range expectedGPUWidths {
+		if actualCount, exists := config.ExpectedGPUWidths[width]; !exists {
+			t.Errorf("Expected GPU width %s not found", width)
+		} else if actualCount != expectedCount {
+			t.Errorf("GPU width %s expected count %d, got %d", width, expectedCount, actualCount)
+		}
+	}
+
+	expectedRDMAWidths := map[string]int{
+		"Width x8":  2,
+		"Width x16": 16,
+	}
+
+	if len(config.ExpectedRDMAWidths) != len(expectedRDMAWidths) {
+		t.Errorf("Expected %d RDMA width entries, got %d", 
+			len(expectedRDMAWidths), len(config.ExpectedRDMAWidths))
+	}
+
+	for width, expectedCount := range expectedRDMAWidths {
+		if actualCount, exists := config.ExpectedRDMAWidths[width]; !exists {
+			t.Errorf("Expected RDMA width %s not found", width)
+		} else if actualCount != expectedCount {
+			t.Errorf("RDMA width %s expected count %d, got %d", width, expectedCount, actualCount)
+		}
+	}
+}
+
+// Test edge cases for width parsing
+func TestParseLspciWidthOutputEdgeCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedCounts map[string]int
+		description    string
+	}{
+		{
+			name:           "Single valid line",
+			input:          "      4           LnkSta:     Speed 16GT/s (ok), Width x2 (ok)",
+			expectedCounts: map[string]int{"Width x2": 4},
+			description:    "Should parse single valid line",
+		},
+		{
+			name: "Invalid count format",
+			input: `      abc         LnkSta:     Speed 16GT/s (ok), Width x2 (ok)
+      4           LnkSta:     Speed 32GT/s (ok), Width x16 (ok)`,
+			expectedCounts: map[string]int{"Width x16": 4},
+			description:    "Should skip lines with invalid count format",
+		},
+		{
+			name:           "Line without LnkSta",
+			input:          "      4           SomeOther:  Speed 16GT/s (ok), Width x2 (ok)",
+			expectedCounts: map[string]int{},
+			description:    "Should skip lines without LnkSta",
+		},
+		{
+			name:           "Line without Width",
+			input:          "      4           LnkSta:     Speed 16GT/s (ok), Speed x2 (ok)",
+			expectedCounts: map[string]int{},
+			description:    "Should skip lines without Width",
+		},
+		{
+			name:           "Malformed Width",
+			input:          "      4           LnkSta:     Speed 16GT/s (ok), Width 2 (ok)",
+			expectedCounts: map[string]int{},
+			description:    "Should skip lines with malformed Width (missing x)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseLspciWidthOutput(tt.input, "ok")
+
+			if len(result.WidthCounts) != len(tt.expectedCounts) {
+				t.Errorf("%s: expected %d width entries, got %d", 
+					tt.description, len(tt.expectedCounts), len(result.WidthCounts))
+			}
+
+			for width, expectedCount := range tt.expectedCounts {
+				if actualCount, exists := result.WidthCounts[width]; !exists {
+					if expectedCount > 0 {
+						t.Errorf("%s: expected width %s not found in result", tt.description, width)
+					}
+				} else if actualCount != expectedCount {
+					t.Errorf("%s: width %s expected count %d, got %d", 
+						tt.description, width, expectedCount, actualCount)
+				}
+			}
+		})
+	}
+}
+
+// Benchmark the PCIe width parsing logic
+func BenchmarkParseLspciWidthOutput(b *testing.B) {
+	input := mockNvidiaLspciOutput + "\n" + mockMellanoxLspciOutput
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parseLspciWidthOutput(input, "ok")
+	}
+}
+
+// Benchmark width validation logic
+func BenchmarkValidateWidthCounts(b *testing.B) {
+	actual := map[string]int{
+		"Width x2":  4,
+		"Width x8":  2,
+		"Width x16": 24,
+	}
+	expected := map[string]int{
+		"Width x2":  4,
+		"Width x8":  2,
+		"Width x16": 24,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		validateWidthCounts(actual, expected, "GPU/NVSwitch")
+	}
+}
+
+// Test the new filtering functions
+const mockLspciFullOutput = `00:00.0 Host bridge: Intel Corporation Device 7d01 (rev 11)
+	Subsystem: Intel Corporation Device 7270
+	Control: I/O- Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
+
+17:00.0 3D controller: NVIDIA Corporation GH200 120GB [Grace Hopper "Superchip"] (rev a1)
+	Subsystem: NVIDIA Corporation Device 1791
+	Control: I/O+ Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx+
+	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
+	Latency: 0
+	Interrupt: pin A routed to IRQ 16
+	Region 0: Memory at c6000000 (32-bit, non-prefetchable) [size=16M]
+	Region 1: Memory at 1800000000 (64-bit, prefetchable) [size=32G]
+	Region 3: Memory at 1900000000 (64-bit, prefetchable) [size=32M]
+	Capabilities: [60] Power Management version 3
+	Capabilities: [68] MSI: Enable+ Count=1/1 Maskable- 64bit+
+	Capabilities: [78] Express (v2) Endpoint, MSI 00
+		DevCap:	MaxPayload 256 bytes, PhantFunc 0, Latency L0s unlimited, L1 <64us
+		DevCtl:	CorrErr+ NonFatalErr+ FatalErr+ UnsupReq+
+		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr- TransPend-
+		LnkCap:	Port #0, Speed 16GT/s, Width x16, ASPM L0s L1, Exit Latency L0s <1us, L1 <4us
+		LnkCtl:	ASPM Disabled; RCB 64 bytes Disabled- CommClk+
+		LnkSta:	Speed 16GT/s (ok), Width x16 (ok)
+
+ca:00.0 Infiniband controller: Mellanox Technologies MT2910 Family [ConnectX-7]
+	Subsystem: Mellanox Technologies Device 0051
+	Control: I/O- Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx+
+	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
+	Latency: 0, Cache Line Size: 64 bytes
+	Interrupt: pin A routed to IRQ 16
+	Region 0: Memory at c4000000 (64-bit, non-prefetchable) [size=32M]
+	Capabilities: [60] Express (v2) Endpoint, MSI 00
+		DevCap:	MaxPayload 512 bytes, PhantFunc 0, Latency L0s <64ns, L1 <1us
+		DevCtl:	CorrErr+ NonFatalErr+ FatalErr+ UnsupReq+
+		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr- TransPend-
+		LnkCap:	Port #0, Speed 32GT/s, Width x16, ASPM not supported
+		LnkCtl:	ASPM Disabled; RCB 128 bytes Disabled- CommClk+
+		LnkSta:	Speed 32GT/s (ok), Width x16 (ok)`
+
+func TestFilterLspciForDevice(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		deviceType     string
+		expectedOutput string
+		description    string
+	}{
+		{
+			name:       "Filter NVIDIA devices",
+			input:      mockLspciFullOutput,
+			deviceType: "nvidia",
+			expectedOutput: "		LnkSta:	Speed 16GT/s (ok), Width x16 (ok)",
+			description: "Should extract LnkSta line for NVIDIA device",
+		},
+		{
+			name:       "Filter Mellanox devices",
+			input:      mockLspciFullOutput,
+			deviceType: "mellanox",
+			expectedOutput: "		LnkSta:	Speed 32GT/s (ok), Width x16 (ok)",
+			description: "Should extract LnkSta line for Mellanox device",
+		},
+		{
+			name:        "No matching devices",
+			input:       mockLspciFullOutput,
+			deviceType:  "amd",
+			expectedOutput: "",
+			description: "Should return empty string when no matching devices found",
+		},
+		{
+			name:        "Empty input",
+			input:       "",
+			deviceType:  "nvidia",
+			expectedOutput: "",
+			description: "Should handle empty input gracefully",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterLspciForDevice(tt.input, tt.deviceType)
+			
+			if strings.TrimSpace(result) != strings.TrimSpace(tt.expectedOutput) {
+				t.Errorf("%s: expected output '%s', got '%s'", 
+					tt.description, strings.TrimSpace(tt.expectedOutput), strings.TrimSpace(result))
+			}
+		})
+	}
+}
+
+func TestAggregateLinkStatistics(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedLines  int
+		description    string
+	}{
+		{
+			name: "Single unique line",
+			input: "		LnkSta:	Speed 16GT/s (ok), Width x16 (ok)",
+			expectedLines: 1,
+			description: "Should return single line with count 1",
+		},
+		{
+			name: "Multiple identical lines", 
+			input: `		LnkSta:	Speed 16GT/s (ok), Width x16 (ok)
+		LnkSta:	Speed 16GT/s (ok), Width x16 (ok)
+		LnkSta:	Speed 16GT/s (ok), Width x16 (ok)`,
+			expectedLines: 1,
+			description: "Should aggregate identical lines",
+		},
+		{
+			name: "Multiple different lines",
+			input: `		LnkSta:	Speed 16GT/s (ok), Width x2 (ok)
+		LnkSta:	Speed 32GT/s (ok), Width x16 (ok)`,
+			expectedLines: 2,
+			description: "Should keep different lines separate",
+		},
+		{
+			name: "Empty input",
+			input: "",
+			expectedLines: 0,
+			description: "Should handle empty input",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := AggregateLinkStatistics(tt.input)
+			
+			if tt.expectedLines == 0 {
+				if result != "" {
+					t.Errorf("%s: expected empty result, got '%s'", tt.description, result)
+				}
+				return
+			}
+			
+			lines := strings.Split(strings.TrimSpace(result), "\n")
+			if len(lines) != tt.expectedLines {
+				t.Errorf("%s: expected %d lines, got %d", tt.description, tt.expectedLines, len(lines))
+			}
+			
+			// Verify each line starts with a count and tab
+			for _, line := range lines {
+				if line != "" {
+					parts := strings.SplitN(line, "\t", 2)
+					if len(parts) != 2 {
+						t.Errorf("%s: line should have count + tab + content format: '%s'", tt.description, line)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -42,6 +42,17 @@ type PCIeTestResult struct {
 	TimestampUTC string `json:"timestamp_utc"`
 }
 
+// PCIeWidthTestResult represents PCIe width test results
+type PCIeWidthTestResult struct {
+	Status          string         `json:"status"`
+	GPUWidthCounts  map[string]int `json:"gpu_width_counts,omitempty"`
+	RDMAWidthCounts map[string]int `json:"rdma_width_counts,omitempty"`
+	GPUSpeedCounts  map[string]int `json:"gpu_speed_counts,omitempty"`
+	RDMASpeedCounts map[string]int `json:"rdma_speed_counts,omitempty"`
+	StateErrors     []string       `json:"state_errors,omitempty"`
+	TimestampUTC    string         `json:"timestamp_utc"`
+}
+
 // RDMATestResult represents RDMA test results
 type RDMATestResult struct {
 	Status       string `json:"status"`
@@ -180,28 +191,29 @@ type RowRemapErrorTestResult struct {
 
 // HostResults represents test results for a host
 type HostResults struct {
-	GPUCountCheck         []GPUTestResult              `json:"gpu_count_check,omitempty"`
-	GPUModeCheck          []GPUModeTestResult          `json:"gpu_mode_check,omitempty"`
-	PCIeErrorCheck        []PCIeTestResult             `json:"pcie_error_check,omitempty"`
-	RDMANicsCount         []RDMATestResult             `json:"rdma_nics_count,omitempty"`
-	RXDiscardsCheck       []RXDiscardsCheckTestResult  `json:"rx_discards_check,omitempty"`
-	GIDIndexCheck         []GIDIndexTestResult         `json:"gid_index_check,omitempty"`
-	LinkCheck             []LinkTestResult             `json:"link_check,omitempty"`
-	EthLinkCheck          []EthLinkTestResult          `json:"eth_link_check,omitempty"`
-	AuthCheck             []AuthCheckTestResult        `json:"auth_check,omitempty"`
-	SRAMErrorCheck        []SRAMErrorTestResult        `json:"sram_error_check,omitempty"`
-	GPUDriverCheck        []GPUDriverTestResult        `json:"gpu_driver_check,omitempty"`
-	GPUClockCheck         []GPUClockTestResult         `json:"gpu_clk_check,omitempty"`
-	PeerMemModuleCheck    []PeerMemTestResult          `json:"peermem_module_check,omitempty"`
-	NVLinkSpeedCheck      []NVLinkTestResult           `json:"nvlink_speed_check,omitempty"`
-	Eth0PresenceCheck     []Eth0PresenceTestResult     `json:"eth0_presence_check,omitempty"`
-	CDFPCableCheck        []CDFPCableCheckTestResult   `json:"cdfp_cable_check,omitempty"`
-	FabricManagerCheck    []FabricManagerTestResult    `json:"fabricmanager_check,omitempty"`
-	HCAErrorCheck         []HCAErrorTestResult         `json:"hca_error_check,omitempty"`
-	MissingInterfaceCheck []MissingInterfaceTestResult `json:"missing_interface_check,omitempty"`
-	GPUXIDCheck           []GPUXIDTestResult           `json:"gpu_xid_check,omitempty"`
-	MaxAccCheck           []MaxAccTestResult           `json:"max_acc_check,omitempty"`
-	RowRemapErrorCheck    []RowRemapErrorTestResult    `json:"row_remap_error_check,omitempty"`
+	GPUCountCheck              []GPUTestResult              `json:"gpu_count_check,omitempty"`
+	GPUModeCheck               []GPUModeTestResult          `json:"gpu_mode_check,omitempty"`
+	PCIeErrorCheck             []PCIeTestResult             `json:"pcie_error_check,omitempty"`
+	PCIeWidthMissingLanesCheck []PCIeWidthTestResult        `json:"pcie_width_missing_lanes_check,omitempty"`
+	RDMANicsCount              []RDMATestResult             `json:"rdma_nics_count,omitempty"`
+	RXDiscardsCheck            []RXDiscardsCheckTestResult  `json:"rx_discards_check,omitempty"`
+	GIDIndexCheck              []GIDIndexTestResult         `json:"gid_index_check,omitempty"`
+	LinkCheck                  []LinkTestResult             `json:"link_check,omitempty"`
+	EthLinkCheck               []EthLinkTestResult          `json:"eth_link_check,omitempty"`
+	AuthCheck                  []AuthCheckTestResult        `json:"auth_check,omitempty"`
+	SRAMErrorCheck             []SRAMErrorTestResult        `json:"sram_error_check,omitempty"`
+	GPUDriverCheck             []GPUDriverTestResult        `json:"gpu_driver_check,omitempty"`
+	GPUClockCheck              []GPUClockTestResult         `json:"gpu_clk_check,omitempty"`
+	PeerMemModuleCheck         []PeerMemTestResult          `json:"peermem_module_check,omitempty"`
+	NVLinkSpeedCheck           []NVLinkTestResult           `json:"nvlink_speed_check,omitempty"`
+	Eth0PresenceCheck          []Eth0PresenceTestResult     `json:"eth0_presence_check,omitempty"`
+	CDFPCableCheck             []CDFPCableCheckTestResult   `json:"cdfp_cable_check,omitempty"`
+	FabricManagerCheck         []FabricManagerTestResult    `json:"fabricmanager_check,omitempty"`
+	HCAErrorCheck              []HCAErrorTestResult         `json:"hca_error_check,omitempty"`
+	MissingInterfaceCheck      []MissingInterfaceTestResult `json:"missing_interface_check,omitempty"`
+	GPUXIDCheck                []GPUXIDTestResult           `json:"gpu_xid_check,omitempty"`
+	MaxAccCheck                []MaxAccTestResult           `json:"max_acc_check,omitempty"`
+	RowRemapErrorCheck         []RowRemapErrorTestResult    `json:"row_remap_error_check,omitempty"`
 }
 
 // ReportOutput represents the final JSON output structure
@@ -322,6 +334,18 @@ func (r *Reporter) AddGPUModeResult(status string, message string, enabledGPUInd
 func (r *Reporter) AddPCIeResult(status string, err error) {
 	details := map[string]interface{}{}
 	r.AddResult("pcie_error_check", status, details, err)
+}
+
+// AddPCIeWidthResult adds PCIe width missing lanes test results
+func (r *Reporter) AddPCIeWidthResult(status string, gpuWidthCounts, rdmaWidthCounts, gpuSpeedCounts, rdmaSpeedCounts map[string]int, stateErrors []string, err error) {
+	details := map[string]interface{}{
+		"gpu_width_counts":  gpuWidthCounts,
+		"rdma_width_counts": rdmaWidthCounts,
+		"gpu_speed_counts":  gpuSpeedCounts,
+		"rdma_speed_counts": rdmaSpeedCounts,
+		"state_errors":      stateErrors,
+	}
+	r.AddResult("pcie_width_missing_lanes_check", status, details, err)
 }
 
 // AddRDMAResult adds RDMA test results
@@ -557,6 +581,53 @@ func (r *Reporter) GenerateReport() (*ReportOutput, error) {
 			TimestampUTC: result.Timestamp.UTC().Format(time.RFC3339),
 		}
 		report.Localhost.PCIeErrorCheck = []PCIeTestResult{pcieResult}
+	}
+
+	// Process PCIe width missing lanes results
+	if result, exists := r.results["pcie_width_missing_lanes_check"]; exists {
+		var gpuWidthCounts, rdmaWidthCounts, gpuSpeedCounts, rdmaSpeedCounts map[string]int
+		var stateErrors []string
+
+		if gpuCountsVal, ok := result.Details["gpu_width_counts"]; ok {
+			if gpuCounts, ok := gpuCountsVal.(map[string]int); ok {
+				gpuWidthCounts = gpuCounts
+			}
+		}
+
+		if rdmaCountsVal, ok := result.Details["rdma_width_counts"]; ok {
+			if rdmaCounts, ok := rdmaCountsVal.(map[string]int); ok {
+				rdmaWidthCounts = rdmaCounts
+			}
+		}
+
+		if gpuSpeedCountsVal, ok := result.Details["gpu_speed_counts"]; ok {
+			if gpuSpeeds, ok := gpuSpeedCountsVal.(map[string]int); ok {
+				gpuSpeedCounts = gpuSpeeds
+			}
+		}
+
+		if rdmaSpeedCountsVal, ok := result.Details["rdma_speed_counts"]; ok {
+			if rdmaSpeeds, ok := rdmaSpeedCountsVal.(map[string]int); ok {
+				rdmaSpeedCounts = rdmaSpeeds
+			}
+		}
+
+		if stateErrorsVal, ok := result.Details["state_errors"]; ok {
+			if stateErrs, ok := stateErrorsVal.([]string); ok {
+				stateErrors = stateErrs
+			}
+		}
+
+		pcieWidthResult := PCIeWidthTestResult{
+			Status:          result.Status,
+			GPUWidthCounts:  gpuWidthCounts,
+			RDMAWidthCounts: rdmaWidthCounts,
+			GPUSpeedCounts:  gpuSpeedCounts,
+			RDMASpeedCounts: rdmaSpeedCounts,
+			StateErrors:     stateErrors,
+			TimestampUTC:    result.Timestamp.UTC().Format(time.RFC3339),
+		}
+		report.Localhost.PCIeWidthMissingLanesCheck = []PCIeWidthTestResult{pcieWidthResult}
 	}
 
 	// Process RDMA results
@@ -1054,6 +1125,20 @@ func (r *Reporter) formatTable(report *ReportOutput) (string, error) {
 		}
 	}
 
+	// PCIe Width Tests
+	if len(report.Localhost.PCIeWidthMissingLanesCheck) > 0 {
+		for _, pcieWidth := range report.Localhost.PCIeWidthMissingLanesCheck {
+			status := pcieWidth.Status
+			statusSymbol := "✅"
+			if status == "FAIL" {
+				statusSymbol = "❌"
+			}
+			details := "PCIe Width Check: " + status
+			output.WriteString(fmt.Sprintf("│ %-22s │ %-6s │ %s %s    │\n",
+				"PCIe Width Check", statusSymbol, statusSymbol, details))
+		}
+	}
+
 	// RDMA Tests
 	if len(report.Localhost.RDMANicsCount) > 0 {
 		for _, rdma := range report.Localhost.RDMANicsCount {
@@ -1469,6 +1554,38 @@ func (r *Reporter) formatFriendly(report *ReportOutput) (string, error) {
 			} else {
 				failedTests++
 				output.WriteString("   ❌ PCIe Bus: Errors detected (FAILED)\n")
+			}
+		}
+		output.WriteString("\n")
+	}
+
+	// PCIe Width Tests
+	if len(report.Localhost.PCIeWidthMissingLanesCheck) > 0 {
+		output.WriteString("📏 PCIe Width Check\n")
+		output.WriteString("   " + strings.Repeat("-", 30) + "\n")
+		for _, pcieWidth := range report.Localhost.PCIeWidthMissingLanesCheck {
+			totalTests++
+			if pcieWidth.Status == "PASS" {
+				passedTests++
+				output.WriteString("   ✅ PCIe Link Width: All lanes operating at expected width (PASSED)\n")
+				if len(pcieWidth.GPUWidthCounts) > 0 {
+					output.WriteString("      GPU/NVSwitch widths: ")
+					for width, count := range pcieWidth.GPUWidthCounts {
+						output.WriteString(fmt.Sprintf("%dx %s ", count, width))
+					}
+					output.WriteString("\n")
+				}
+				if len(pcieWidth.RDMAWidthCounts) > 0 {
+					output.WriteString("      RDMA widths: ")
+					for width, count := range pcieWidth.RDMAWidthCounts {
+						output.WriteString(fmt.Sprintf("%dx %s ", count, width))
+					}
+					output.WriteString("\n")
+				}
+			} else {
+				failedTests++
+				output.WriteString("   ❌ PCIe Link Width: Missing lanes detected (FAILED)\n")
+				output.WriteString("      ⚠️  Please reboot the host and if the issue persists, send the node to OCI\n")
 			}
 		}
 		output.WriteString("\n")

--- a/internal/test_limits/test_limits.json
+++ b/internal/test_limits/test_limits.json
@@ -15,6 +15,29 @@
         "enabled": true,
         "test_category": "LEVEL_1"
       },
+      "pcie_width_missing_lanes_check": {
+        "enabled": true,
+        "test_category": "LEVEL_1",
+        "threshold": {
+          "gpu_widths": {
+            "Width x2": 4,
+            "Width x16": 8
+          },
+          "rdma_widths": {
+            "Width x8": 2,
+            "Width x16": 16
+          },
+          "gpu_speeds": {
+            "Speed 16GT/s": 4,
+            "Speed 32GT/s": 8
+          },
+          "rdma_speeds": {
+            "Speed 16GT/s": 2,
+            "Speed 32GT/s": 16
+          },
+          "expected_link_state": "ok"
+        }
+      },
       "gpu_count_check": {
         "threshold": 8,
         "enabled": true,

--- a/internal/test_limits/test_limits_test.go
+++ b/internal/test_limits/test_limits_test.go
@@ -284,33 +284,34 @@ func TestGetEnabledTests(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to get enabled tests: %v", err)
 	}
-	if len(enabledTests) != 22 {
-		t.Errorf("Expected 22 enabled tests for H100, got %d", len(enabledTests))
+	if len(enabledTests) != 23 {
+		t.Errorf("Expected 23 enabled tests for H100, got %d", len(enabledTests))
 	}
 
 	expectedTests := map[string]bool{
-		"gid_index_check":         false,
-		"gpu_mode_check":          false,
-		"rx_discards_check":       false,
-		"sram_error_check":        false,
-		"gpu_count_check":         false,
-		"rdma_nic_count":          false,
-		"pcie_error_check":        false,
-		"link_check":              false,
-		"eth_link_check":          false,
-		"auth_check":              false,
-		"gpu_driver_check":        false,
-		"gpu_clk_check":           false,
-		"peermem_module_check":    false,
-		"nvlink_speed_check":      false,
-		"eth0_presence_check":     false,
-		"cdfp_cable_check":        false,
-		"fabricmanager_check":     false,
-		"hca_error_check":         false,
-		"missing_interface_check": false,
-		"gpu_xid_check":           false,
-		"max_acc_check":           false,
-		"row_remap_error_check":   false,
+		"gid_index_check":                  false,
+		"gpu_mode_check":                   false,
+		"rx_discards_check":                false,
+		"sram_error_check":                 false,
+		"gpu_count_check":                  false,
+		"rdma_nic_count":                   false,
+		"pcie_error_check":                 false,
+		"pcie_width_missing_lanes_check":   false,
+		"link_check":                       false,
+		"eth_link_check":                   false,
+		"auth_check":                       false,
+		"gpu_driver_check":                 false,
+		"gpu_clk_check":                    false,
+		"peermem_module_check":             false,
+		"nvlink_speed_check":               false,
+		"eth0_presence_check":              false,
+		"cdfp_cable_check":                 false,
+		"fabricmanager_check":              false,
+		"hca_error_check":                  false,
+		"missing_interface_check":          false,
+		"gpu_xid_check":                    false,
+		"max_acc_check":                    false,
+		"row_remap_error_check":            false,
 	}
 
 	for _, test := range enabledTests {

--- a/scripts/BM.GPU.H100.8/pcie_width_missing_lanes_check.py
+++ b/scripts/BM.GPU.H100.8/pcie_width_missing_lanes_check.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+
+"""
+PCIe Width Missing Lanes Check
+
+This script checks the PCIe link width for GPU and RDMA interfaces to detect missing lanes.
+It verifies that all PCIe links are operating at their expected width configuration.
+
+Expected output for BM.GPU.H100.8:
+- GPU/NVSwitch: 4x Width x2 (ok), 8x Width x16 (ok)  
+- RDMA: 2x Width x8 (ok), 16x Width x16 (ok)
+
+Author: Oracle Cloud Infrastructure
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+
+def run_command(cmd: str) -> Tuple[int, str, str]:
+    """
+    Execute a shell command and return exit code, stdout, stderr.
+    
+    Args:
+        cmd: Command to execute
+        
+    Returns:
+        Tuple of (exit_code, stdout, stderr)
+    """
+    try:
+        result = subprocess.run(
+            cmd, 
+            shell=True, 
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, 
+            universal_newlines=True, 
+            timeout=30
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 124, "", "Command timed out"
+    except Exception as e:
+        return 1, "", str(e)
+
+
+def parse_lspci_width_output(output: str) -> Tuple[Dict[str, int], Dict[str, int], List[str]]:
+    """
+    Parse lspci output to extract PCIe width, speed, and state information.
+    
+    Args:
+        output: Raw output from lspci command
+        
+    Returns:
+        Tuple of (width_counts, speed_counts, state_errors)
+    """
+    width_counts = {}
+    speed_counts = {}
+    state_errors = []
+    
+    lines = output.strip().split('\n')
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+            
+        # Parse line format: "count           LnkSta: Speed 16GT/s (ok), Width x16 (ok)"
+        import re
+        match = re.match(r'^\s*(\d+)\s+LnkSta:\s*Speed\s+([^\s]+)\s*\(([^)]+)\),\s*Width\s+x(\d+)\s*\(([^)]+)\)', line)
+        if match:
+            try:
+                count = int(match.group(1))
+                speed = match.group(2)
+                speed_state = match.group(3)
+                width = match.group(4)
+                width_state = match.group(5)
+                
+                # Count widths only if width state is ok
+                width_key = f"Width x{width}"
+                if width_state == "ok":
+                    width_counts[width_key] = width_counts.get(width_key, 0) + count
+                else:
+                    state_errors.append(f"{count} devices have width state '{width_state}' instead of 'ok'")
+                
+                # Count speeds only if speed state is ok
+                speed_key = f"Speed {speed}"
+                if speed_state == "ok":
+                    speed_counts[speed_key] = speed_counts.get(speed_key, 0) + count
+                else:
+                    state_errors.append(f"{count} devices have speed state '{speed_state}' instead of 'ok'")
+                    
+            except (ValueError, IndexError):
+                continue
+                
+    return width_counts, speed_counts, state_errors
+
+
+def check_gpu_nvswitch_pcie_width() -> Tuple[bool, str, Dict[str, int], Dict[str, int], List[str]]:
+    """
+    Check PCIe width, speed, and state for GPU and NVSwitch interfaces.
+    
+    Returns:
+        Tuple of (success, error_message, width_counts, speed_counts, state_errors)
+    """
+    cmd = "sudo lspci -vvv | egrep '^[0-9,a-f]|LnkSta:' | grep -A 1 -i nvidia | grep LnkSta | sort | uniq -c"
+    
+    exit_code, stdout, stderr = run_command(cmd)
+    
+    if exit_code != 0:
+        return False, f"Failed to execute lspci command: {stderr}", {}, {}, []
+    
+    if not stdout.strip():
+        return False, "No NVIDIA PCIe devices found", {}, {}, []
+    
+    width_counts, speed_counts, state_errors = parse_lspci_width_output(stdout)
+    
+    # Expected for BM.GPU.H100.8: 4x Width x2, 8x Width x16
+    expected_width_counts = {
+        "Width x2": 4,
+        "Width x16": 8
+    }
+    
+    # Expected for BM.GPU.H100.8: 4x Speed 16GT/s, 8x Speed 32GT/s
+    expected_speed_counts = {
+        "Speed 16GT/s": 4,
+        "Speed 32GT/s": 8
+    }
+    
+    error_messages = []
+    
+    # Check width counts
+    for width, expected_count in expected_width_counts.items():
+        actual_count = width_counts.get(width, 0)
+        if actual_count != expected_count:
+            error_messages.append(f"GPU/NVSwitch PCIe width mismatch: expected {expected_count}x {width}, got {actual_count}x")
+    
+    # Check speed counts
+    for speed, expected_count in expected_speed_counts.items():
+        actual_count = speed_counts.get(speed, 0)
+        if actual_count != expected_count:
+            error_messages.append(f"GPU/NVSwitch PCIe speed mismatch: expected {expected_count}x {speed}, got {actual_count}x")
+    
+    # Add state errors
+    if state_errors:
+        error_messages.extend([f"GPU/NVSwitch state error: {err}" for err in state_errors])
+    
+    if error_messages:
+        return False, "; ".join(error_messages), width_counts, speed_counts, state_errors
+    
+    return True, "", width_counts, speed_counts, state_errors
+
+
+def check_rdma_pcie_width() -> Tuple[bool, str, Dict[str, int], Dict[str, int], List[str]]:
+    """
+    Check PCIe width, speed, and state for RDMA interfaces.
+    
+    Returns:
+        Tuple of (success, error_message, width_counts, speed_counts, state_errors)
+    """
+    cmd = "sudo lspci -vvv | egrep '^[0-9,a-f]|LnkSta:' | grep -A 1 -i mellanox | grep LnkSta | sort | uniq -c"
+    
+    exit_code, stdout, stderr = run_command(cmd)
+    
+    if exit_code != 0:
+        return False, f"Failed to execute lspci command: {stderr}", {}, {}, []
+    
+    if not stdout.strip():
+        return False, "No Mellanox PCIe devices found", {}, {}, []
+    
+    width_counts, speed_counts, state_errors = parse_lspci_width_output(stdout)
+    
+    # Expected for BM.GPU.H100.8: 2x Width x8, 16x Width x16
+    expected_width_counts = {
+        "Width x8": 2,
+        "Width x16": 16
+    }
+    
+    # Expected for BM.GPU.H100.8: 2x Speed 16GT/s, 16x Speed 32GT/s
+    expected_speed_counts = {
+        "Speed 16GT/s": 2,
+        "Speed 32GT/s": 16
+    }
+    
+    error_messages = []
+    
+    # Check width counts
+    for width, expected_count in expected_width_counts.items():
+        actual_count = width_counts.get(width, 0)
+        if actual_count != expected_count:
+            error_messages.append(f"RDMA PCIe width mismatch: expected {expected_count}x {width}, got {actual_count}x")
+    
+    # Check speed counts
+    for speed, expected_count in expected_speed_counts.items():
+        actual_count = speed_counts.get(speed, 0)
+        if actual_count != expected_count:
+            error_messages.append(f"RDMA PCIe speed mismatch: expected {expected_count}x {speed}, got {actual_count}x")
+    
+    # Add state errors
+    if state_errors:
+        error_messages.extend([f"RDMA state error: {err}" for err in state_errors])
+    
+    if error_messages:
+        return False, "; ".join(error_messages), width_counts, speed_counts, state_errors
+    
+    return True, "", width_counts, speed_counts, state_errors
+
+
+def get_oci_shape() -> str:
+    """
+    Get the current OCI shape from IMDS or environment variable.
+    
+    Returns:
+        OCI shape string
+    """
+    # First try environment variable (useful for testing)
+    shape = os.environ.get("OCI_SHAPE")
+    if shape:
+        return shape
+    
+    # Try IMDS
+    try:
+        cmd = "curl -s -m 10 http://169.254.169.254/opc/v1/instance/shape"
+        exit_code, stdout, stderr = run_command(cmd)
+        if exit_code == 0 and stdout.strip():
+            return stdout.strip()
+    except Exception:
+        pass
+    
+    return "UNKNOWN"
+
+
+def main():
+    """Main function to run PCIe width missing lanes check."""
+    
+    overall_success = True
+    error_messages = []
+    
+    # Check GPU/NVSwitch PCIe width, speed, and state
+    gpu_success, gpu_error, gpu_width_counts, gpu_speed_counts, gpu_state_errors = check_gpu_nvswitch_pcie_width()
+    
+    if not gpu_success:
+        overall_success = False
+        error_messages.append(f"GPU/NVSwitch: {gpu_error}")
+    
+    # Check RDMA PCIe width, speed, and state
+    rdma_success, rdma_error, rdma_width_counts, rdma_speed_counts, rdma_state_errors = check_rdma_pcie_width()
+    
+    if not rdma_success:
+        overall_success = False
+        error_messages.append(f"RDMA: {rdma_error}")
+    
+    # Create result in simple format matching other scripts
+    if overall_success:
+        status = "PASS"
+    else:
+        status = f"FAIL - {'; '.join(error_messages)}"
+    
+    result = {
+        "pcie_width_missing_lanes": {
+            "status": status
+        }
+    }
+    
+    print(json.dumps(result, indent=2))
+    
+    # Exit with appropriate code
+    return 0 if overall_success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/BM.GPU.H100.8/pcie_width_missing_lanes_check.sh
+++ b/scripts/BM.GPU.H100.8/pcie_width_missing_lanes_check.sh
@@ -1,0 +1,399 @@
+#!/bin/bash
+
+# PCIe Width Missing Lanes Check
+#
+# This script checks the PCIe link width for GPU and RDMA interfaces to detect missing lanes.
+# It verifies that all PCIe links are operating at their expected width configuration.
+#
+# Expected output for BM.GPU.H100.8:
+# - GPU/NVSwitch: 4x Width x2 (ok), 8x Width x16 (ok)  
+# - RDMA: 2x Width x8 (ok), 16x Width x16 (ok)
+#
+# Author: Oracle Cloud Infrastructure
+
+set -euo pipefail
+
+# Global variables
+SCRIPT_NAME="pcie_width_missing_lanes_check"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+IS_TERMINAL=false
+
+# Check if we're running in a terminal
+if [[ -t 1 ]]; then
+    IS_TERMINAL=true
+fi
+
+# Function to log messages
+log_info() {
+    if [[ "$IS_TERMINAL" == "true" ]]; then
+        echo "INFO: $*" >&2
+    fi
+}
+
+log_error() {
+    if [[ "$IS_TERMINAL" == "true" ]]; then
+        echo "ERROR: $*" >&2
+    fi
+}
+
+# Function to run command with timeout
+run_command() {
+    local cmd="$1"
+    local timeout_duration=30
+    
+    if timeout "$timeout_duration" bash -c "$cmd" 2>/dev/null; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Function to parse lspci width output
+parse_lspci_width_output() {
+    local output="$1"
+    local -A width_counts
+    local -A speed_counts
+    local state_errors=()
+    
+    while IFS= read -r line; do
+        if [[ -z "$line" ]]; then
+            continue
+        fi
+        
+        # Parse line format: "count           LnkSta: Speed 16GT/s (ok), Width x16 (ok)"
+        # Use simpler parsing with sed/grep for better compatibility
+        if echo "$line" | grep -q "LnkSta:.*Speed.*Width"; then
+            local count=$(echo "$line" | sed -n 's/^[[:space:]]*\([0-9]\+\).*/\1/p')
+            local speed=$(echo "$line" | sed -n 's/.*Speed[[:space:]]\+\([^[:space:]]\+\).*/\1/p')
+            local speed_state=$(echo "$line" | sed -n 's/.*Speed[[:space:]]\+[^[:space:]]\+[[:space:]]*(\([^)]*\)).*/\1/p')
+            local width=$(echo "$line" | sed -n 's/.*Width[[:space:]]\+x\([0-9]\+\).*/\1/p')
+            local width_state=$(echo "$line" | sed -n 's/.*Width[[:space:]]\+x[0-9]\+[[:space:]]*(\([^)]*\)).*/\1/p')
+            
+            # Only process if we got valid values
+            if [[ -n "$count" && -n "$width" && -n "$speed" ]]; then
+                # Count widths only if width state is ok
+                if [[ "$width_state" == "ok" ]]; then
+                    width_counts["Width x${width}"]="$count"
+                else
+                    state_errors+=("$count devices have width state '$width_state' instead of 'ok'")
+                fi
+                
+                # Count speeds only if speed state is ok
+                if [[ "$speed_state" == "ok" ]]; then
+                    speed_counts["Speed ${speed}"]="$count"
+                else
+                    state_errors+=("$count devices have speed state '$speed_state' instead of 'ok'")
+                fi
+            fi
+        fi
+    done <<< "$output"
+    
+    # Output format: width_counts|speed_counts|state_errors
+    local width_json="{"
+    local first=true
+    for width in "${!width_counts[@]}"; do
+        if [[ "$first" == "false" ]]; then
+            width_json="$width_json, "
+        fi
+        width_json="$width_json\"$width\": ${width_counts[$width]}"
+        first=false
+    done
+    width_json="$width_json}"
+    
+    local speed_json="{"
+    first=true
+    for speed in "${!speed_counts[@]}"; do
+        if [[ "$first" == "false" ]]; then
+            speed_json="$speed_json, "
+        fi
+        speed_json="$speed_json\"$speed\": ${speed_counts[$speed]}"
+        first=false
+    done
+    speed_json="$speed_json}"
+    
+    local errors_json="["
+    first=true
+    for error in "${state_errors[@]}"; do
+        if [[ "$first" == "false" ]]; then
+            errors_json="$errors_json, "
+        fi
+        errors_json="$errors_json\"$error\""
+        first=false
+    done
+    errors_json="$errors_json]"
+    
+    echo "$width_json|$speed_json|$errors_json"
+}
+
+# Function to check GPU/NVSwitch PCIe width, speed, and state
+check_gpu_nvswitch_pcie_width() {
+    local cmd="sudo lspci -vvv | egrep '^[0-9,a-f]|LnkSta:' | grep -A 1 -i nvidia | grep LnkSta | sort | uniq -c"
+    local output
+    local gpu_success=true
+    local error_messages=()
+    
+    log_info "Checking GPU/NVSwitch PCIe width, speed, and state..."
+    
+    if ! output=$(run_command "$cmd"); then
+        echo "false|Failed to execute lspci command for NVIDIA devices|{}|{}|[]"
+        return
+    fi
+    
+    if [[ -z "$output" ]]; then
+        echo "false|No NVIDIA PCIe devices found|{}|{}|[]"
+        return
+    fi
+    
+    # Parse width, speed, and state data
+    local parse_result
+    parse_result=$(parse_lspci_width_output "$output")
+    IFS='|' read -r width_json speed_json errors_json <<< "$parse_result"
+    
+    # Expected for BM.GPU.H100.8: 4x Width x2, 8x Width x16
+    local expected_x2=4
+    local expected_x16=8
+    # Expected speeds: 4x Speed 16GT/s, 8x Speed 32GT/s
+    local expected_16gt=4
+    local expected_32gt=8
+    
+    # Extract actual width counts from JSON-like format
+    local actual_x2=0
+    local actual_x16=0
+    if [[ $width_json == *'"Width x2":'* ]]; then
+        actual_x2=$(echo "$width_json" | sed -n 's/.*"Width x2": *\([0-9]\+\).*/\1/p')
+    fi
+    if [[ $width_json == *'"Width x16":'* ]]; then
+        actual_x16=$(echo "$width_json" | sed -n 's/.*"Width x16": *\([0-9]\+\).*/\1/p')
+    fi
+    
+    # Extract actual speed counts
+    local actual_16gt=0
+    local actual_32gt=0
+    if [[ $speed_json == *'"Speed 16GT/s":'* ]]; then
+        actual_16gt=$(echo "$speed_json" | sed -n 's/.*"Speed 16GT\/s": *\([0-9]\+\).*/\1/p')
+    fi
+    if [[ $speed_json == *'"Speed 32GT/s":'* ]]; then
+        actual_32gt=$(echo "$speed_json" | sed -n 's/.*"Speed 32GT\/s": *\([0-9]\+\).*/\1/p')
+    fi
+    
+    # Check width counts
+    if [[ $actual_x2 -ne $expected_x2 ]]; then
+        error_messages+=("GPU/NVSwitch PCIe width mismatch: expected ${expected_x2}x Width x2, got ${actual_x2}x Width x2")
+        gpu_success=false
+    fi
+    if [[ $actual_x16 -ne $expected_x16 ]]; then
+        error_messages+=("GPU/NVSwitch PCIe width mismatch: expected ${expected_x16}x Width x16, got ${actual_x16}x Width x16")
+        gpu_success=false
+    fi
+    
+    # Check speed counts
+    if [[ $actual_16gt -ne $expected_16gt ]]; then
+        error_messages+=("GPU/NVSwitch PCIe speed mismatch: expected ${expected_16gt}x Speed 16GT/s, got ${actual_16gt}x Speed 16GT/s")
+        gpu_success=false
+    fi
+    if [[ $actual_32gt -ne $expected_32gt ]]; then
+        error_messages+=("GPU/NVSwitch PCIe speed mismatch: expected ${expected_32gt}x Speed 32GT/s, got ${actual_32gt}x Speed 32GT/s")
+        gpu_success=false
+    fi
+    
+    # Check state errors
+    if [[ $errors_json != "[]" ]]; then
+        # Parse state errors from JSON array
+        local state_error_count
+        state_error_count=$(echo "$errors_json" | grep -o '"[^"]*"' | wc -l)
+        if [[ $state_error_count -gt 0 ]]; then
+            error_messages+=("GPU/NVSwitch state errors detected")
+            gpu_success=false
+        fi
+    fi
+    
+    # Join error messages
+    local final_error=""
+    if [[ ${#error_messages[@]} -gt 0 ]]; then
+        final_error=$(IFS='; '; echo "${error_messages[*]}")
+    fi
+    
+    # Format output: success|error_message|width_json|speed_json|errors_json
+    echo "$gpu_success|$final_error|$width_json|$speed_json|$errors_json"
+}
+
+# Function to check RDMA PCIe width, speed, and state
+check_rdma_pcie_width() {
+    local cmd="sudo lspci -vvv | egrep '^[0-9,a-f]|LnkSta:' | grep -A 1 -i mellanox | grep LnkSta | sort | uniq -c"
+    local output
+    local rdma_success=true
+    local error_messages=()
+    
+    log_info "Checking RDMA PCIe width, speed, and state..."
+    
+    if ! output=$(run_command "$cmd"); then
+        echo "false|Failed to execute lspci command for Mellanox devices|{}|{}|[]"
+        return
+    fi
+    
+    if [[ -z "$output" ]]; then
+        echo "false|No Mellanox PCIe devices found|{}|{}|[]"
+        return
+    fi
+    
+    # Parse width, speed, and state data
+    local parse_result
+    parse_result=$(parse_lspci_width_output "$output")
+    IFS='|' read -r width_json speed_json errors_json <<< "$parse_result"
+    
+    # Expected for BM.GPU.H100.8: 2x Width x8, 16x Width x16
+    local expected_x8=2
+    local expected_x16=16
+    # Expected speeds: 2x Speed 16GT/s, 16x Speed 32GT/s
+    local expected_16gt=2
+    local expected_32gt=16
+    
+    # Extract actual width counts from JSON-like format
+    local actual_x8=0
+    local actual_x16=0
+    if [[ $width_json == *'"Width x8":'* ]]; then
+        actual_x8=$(echo "$width_json" | sed -n 's/.*"Width x8": *\([0-9]\+\).*/\1/p')
+    fi
+    if [[ $width_json == *'"Width x16":'* ]]; then
+        actual_x16=$(echo "$width_json" | sed -n 's/.*"Width x16": *\([0-9]\+\).*/\1/p')
+    fi
+    
+    # Extract actual speed counts
+    local actual_16gt=0
+    local actual_32gt=0
+    if [[ $speed_json == *'"Speed 16GT/s":'* ]]; then
+        actual_16gt=$(echo "$speed_json" | sed -n 's/.*"Speed 16GT\/s": *\([0-9]\+\).*/\1/p')
+    fi
+    if [[ $speed_json == *'"Speed 32GT/s":'* ]]; then
+        actual_32gt=$(echo "$speed_json" | sed -n 's/.*"Speed 32GT\/s": *\([0-9]\+\).*/\1/p')
+    fi
+    
+    # Check width counts
+    if [[ $actual_x8 -ne $expected_x8 ]]; then
+        error_messages+=("RDMA PCIe width mismatch: expected ${expected_x8}x Width x8, got ${actual_x8}x Width x8")
+        rdma_success=false
+    fi
+    if [[ $actual_x16 -ne $expected_x16 ]]; then
+        error_messages+=("RDMA PCIe width mismatch: expected ${expected_x16}x Width x16, got ${actual_x16}x Width x16")
+        rdma_success=false
+    fi
+    
+    # Check speed counts
+    if [[ $actual_16gt -ne $expected_16gt ]]; then
+        error_messages+=("RDMA PCIe speed mismatch: expected ${expected_16gt}x Speed 16GT/s, got ${actual_16gt}x Speed 16GT/s")
+        rdma_success=false
+    fi
+    if [[ $actual_32gt -ne $expected_32gt ]]; then
+        error_messages+=("RDMA PCIe speed mismatch: expected ${expected_32gt}x Speed 32GT/s, got ${actual_32gt}x Speed 32GT/s")
+        rdma_success=false
+    fi
+    
+    # Check state errors
+    if [[ $errors_json != "[]" ]]; then
+        # Parse state errors from JSON array
+        local state_error_count
+        state_error_count=$(echo "$errors_json" | grep -o '"[^"]*"' | wc -l)
+        if [[ $state_error_count -gt 0 ]]; then
+            error_messages+=("RDMA state errors detected")
+            rdma_success=false
+        fi
+    fi
+    
+    # Join error messages
+    local final_error=""
+    if [[ ${#error_messages[@]} -gt 0 ]]; then
+        final_error=$(IFS='; '; echo "${error_messages[*]}")
+    fi
+    
+    # Format output: success|error_message|width_json|speed_json|errors_json
+    echo "$rdma_success|$final_error|$width_json|$speed_json|$errors_json"
+}
+
+# Function to get OCI shape
+get_oci_shape() {
+    local shape
+    
+    # First try environment variable
+    if [[ -n "${OCI_SHAPE:-}" ]]; then
+        echo "$OCI_SHAPE"
+        return
+    fi
+    
+    # Try IMDS
+    if shape=$(curl -s -m 10 http://169.254.169.254/opc/v1/instance/shape 2>/dev/null); then
+        if [[ -n "$shape" ]]; then
+            echo "$shape"
+            return
+        fi
+    fi
+    
+    echo "UNKNOWN"
+}
+
+# Main function
+main() {
+    log_info "Starting PCIe width missing lanes check..."
+    
+    # Get OCI shape
+    local shape
+    shape=$(get_oci_shape)
+    
+    # Initialize variables
+    local overall_success=true
+    local error_messages=()
+    local gpu_width_counts="{}"
+    local gpu_speed_counts="{}"
+    local gpu_state_errors="[]"
+    local rdma_width_counts="{}"
+    local rdma_speed_counts="{}"
+    local rdma_state_errors="[]"
+    
+    # Check GPU/NVSwitch PCIe width, speed, and state
+    local gpu_result
+    gpu_result=$(check_gpu_nvswitch_pcie_width)
+    IFS='|' read -r gpu_success gpu_error gpu_width_counts gpu_speed_counts gpu_state_errors <<< "$gpu_result"
+    
+    if [[ "$gpu_success" != "true" ]]; then
+        overall_success=false
+        error_messages+=("GPU/NVSwitch: $gpu_error")
+    fi
+    
+    # Check RDMA PCIe width, speed, and state
+    local rdma_result
+    rdma_result=$(check_rdma_pcie_width)
+    IFS='|' read -r rdma_success rdma_error rdma_width_counts rdma_speed_counts rdma_state_errors <<< "$rdma_result"
+    
+    if [[ "$rdma_success" != "true" ]]; then
+        overall_success=false
+        error_messages+=("RDMA: $rdma_error")
+    fi
+    
+    # Determine final status
+    local result_status="PASS"
+    
+    if [[ "$overall_success" != "true" ]]; then
+        # Join error messages with "; "
+        local joined_errors
+        joined_errors=$(IFS='; '; echo "${error_messages[*]}")
+        result_status="FAIL - ${joined_errors}"
+    fi
+    
+    # Output result in JSON format using jq (like other scripts)
+    jq -n \
+        --arg status "$result_status" \
+        '{
+            "pcie_width_missing_lanes": {
+                "status": $status
+            }
+        }'
+    
+    # Exit with appropriate code
+    if [[ "$overall_success" == "true" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Execute main function
+main "$@"


### PR DESCRIPTION
## Summary

This PR implements a new diagnostic test `pcie_width_missing_lanes_check` for the BM.GPU.H100.8 shape. The test validates PCIe link width, speed, and state for both GPU/NVSwitch and RDMA interfaces to detect missing lanes or improper configurations.

## Changes

- Added Python script `/scripts/BM.GPU.H100.8/pcie_width_missing_lanes_check.py`
- Added Bash script `/scripts/BM.GPU.H100.8/pcie_width_missing_lanes_check.sh`
- Added Go implementation in `/internal/level1_tests/pcie_width_missing_lanes_check.go`
- Added test file `/internal/level1_tests/pcie_width_missing_lanes_check_test.go`
- Updated test configuration in `/internal/test_limits/test_limits.json`
- Updated recommendations in `/configs/recommendations.json`
- Enhanced executor module with `RunLspciPCIeWidth()` function
- Updated reporter module to support PCIe width test results
- Added support for table, friendly, and JSON output formats

## Test Plan

- [ ] Verify all existing tests continue to pass
- [ ] Confirm new test runs successfully on BM.GPU.H100.8 instances
- [ ] Validate Python and Bash scripts produce expected output
- [ ] Test error conditions and edge cases
- [ ] Verify output formatting across all report modes
- [ ] Confirm cross-platform compilation with `make all-cross`